### PR TITLE
[#6] 전역 예외 처리 구현

### DIFF
--- a/api/src/main/kotlin/com/recap/api/global/config/SecurityConfiguration.kt
+++ b/api/src/main/kotlin/com/recap/api/global/config/SecurityConfiguration.kt
@@ -1,0 +1,41 @@
+package com.recap.api.global.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.recap.api.global.exception.SecurityExceptionHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfiguration {
+    @Bean
+    fun securityFilterChain(
+        http: HttpSecurity,
+        securityExceptionHandler: SecurityExceptionHandler
+    ): SecurityFilterChain =
+        with(http) {
+            csrf { it.disable() }
+            formLogin { it.disable() }
+            logout { it.disable() }
+            sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            exceptionHandling {
+                it
+                    .authenticationEntryPoint(securityExceptionHandler)
+                    .accessDeniedHandler(securityExceptionHandler)
+            }
+            authorizeHttpRequests {
+                it
+                    .anyRequest()
+                    .authenticated()
+            }
+            build()
+        }
+
+    @Bean
+    fun securityExceptionHandler(objectMapper: ObjectMapper): SecurityExceptionHandler =
+        SecurityExceptionHandler(objectMapper = objectMapper)
+}

--- a/api/src/main/kotlin/com/recap/api/global/dto/ErrorResponse.kt
+++ b/api/src/main/kotlin/com/recap/api/global/dto/ErrorResponse.kt
@@ -1,0 +1,6 @@
+package com.recap.api.global.dto
+
+data class ErrorResponse(
+    val code: String,
+    val message: String
+)

--- a/api/src/main/kotlin/com/recap/api/global/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/recap/api/global/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,91 @@
+package com.recap.api.global.exception
+
+import com.recap.api.global.dto.ErrorResponse
+import com.recap.core.global.exception.ServerException
+import com.recap.core.global.util.getLogger
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+
+@RestControllerAdvice(basePackages = ["com.recap.api"])
+class GlobalExceptionHandler {
+    companion object {
+        private const val INTERNAL_SERVER_ERROR_CODE = "INTERNAL_SERVER_ERROR"
+        private const val INTERNAL_SERVER_ERROR_MESSAGE = "서버 오류가 발생했습니다."
+        private val logger = getLogger()
+    }
+
+    @ExceptionHandler(ServerException::class)
+    fun handle(exception: ServerException): ResponseEntity<ErrorResponse> =
+        with(exception) {
+            logger.warn { message }
+
+            val code =
+                this::class
+                    .simpleName!!
+                    .run {
+                        replace(Regex("([a-z])([A-Z])"), "$1_$2")
+                            .uppercase()
+                            .removeSuffix("_EXCEPTION")
+                    }
+            val response =
+                ErrorResponse(
+                    code = code,
+                    message = message
+                )
+
+            ResponseEntity
+                .status(status)
+                .body(response)
+        }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handle(exception: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> =
+        handle(
+            InvalidRequestException(
+                message =
+                    exception.bindingResult
+                        .allErrors
+                        .mapNotNull { it.defaultMessage }
+                        .joinToString(", ")
+            )
+        )
+
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handle(exception: ConstraintViolationException): ResponseEntity<ErrorResponse> =
+        handle(
+            InvalidRequestException(
+                message =
+                    exception.constraintViolations
+                        .joinToString(", ") { "${it.propertyPath.last()} ${it.message}" }
+            )
+        )
+
+    @ExceptionHandler(
+        HttpRequestMethodNotSupportedException::class,
+        HttpMessageNotReadableException::class,
+        MethodArgumentTypeMismatchException::class
+    )
+    fun handle(): ResponseEntity<ErrorResponse> = handle(InvalidRequestException())
+
+    @ExceptionHandler(Exception::class)
+    fun handle(exception: Exception): ResponseEntity<ErrorResponse> {
+        logger.error(exception) { exception.message }
+
+        val response =
+            ErrorResponse(
+                code = INTERNAL_SERVER_ERROR_CODE,
+                message = INTERNAL_SERVER_ERROR_MESSAGE
+            )
+
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(response)
+    }
+}

--- a/api/src/main/kotlin/com/recap/api/global/exception/InvalidRequestException.kt
+++ b/api/src/main/kotlin/com/recap/api/global/exception/InvalidRequestException.kt
@@ -1,0 +1,7 @@
+package com.recap.api.global.exception
+
+import com.recap.core.global.exception.ServerException
+
+data class InvalidRequestException(
+    override val message: String = "잘못된 요청입니다."
+) : ServerException(status = 400, message)

--- a/api/src/main/kotlin/com/recap/api/global/exception/SecurityExceptionHandler.kt
+++ b/api/src/main/kotlin/com/recap/api/global/exception/SecurityExceptionHandler.kt
@@ -1,0 +1,61 @@
+package com.recap.api.global.exception
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.recap.api.global.dto.ErrorResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.access.AccessDeniedHandler
+
+class SecurityExceptionHandler(
+    private val objectMapper: ObjectMapper
+) : AuthenticationEntryPoint,
+    AccessDeniedHandler {
+    companion object {
+        private const val UNAUTHENTICATED_CODE = "UNAUTHENTICATED"
+        private const val UNAUTHENTICATED_MESSAGE = "인증되지 않은 사용자입니다."
+        private const val UNAUTHORIZED_CODE = "UNAUTHORIZED"
+        private const val UNAUTHORIZED_MESSAGE = "인가되지 않은 사용자입니다."
+    }
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        exception: AuthenticationException
+    ) {
+        with(response) {
+            status = HttpStatus.UNAUTHORIZED.value()
+            writeError(
+                ErrorResponse(
+                    code = UNAUTHENTICATED_CODE,
+                    message = UNAUTHENTICATED_MESSAGE
+                )
+            )
+        }
+    }
+
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        exception: AccessDeniedException
+    ) {
+        with(response) {
+            status = HttpStatus.FORBIDDEN.value()
+            writeError(
+                ErrorResponse(
+                    code = UNAUTHORIZED_CODE,
+                    message = UNAUTHORIZED_MESSAGE
+                )
+            )
+        }
+    }
+
+    private fun HttpServletResponse.writeError(response: ErrorResponse) {
+        contentType = MediaType.APPLICATION_JSON_VALUE
+        writer.write(objectMapper.writeValueAsString(response))
+    }
+}

--- a/api/src/testFixtures/kotlin/com/recap/api/snippet/CommonSnippet.kt
+++ b/api/src/testFixtures/kotlin/com/recap/api/snippet/CommonSnippet.kt
@@ -1,0 +1,11 @@
+package com.recap.api.snippet
+
+import com.recap.api.global.dto.ErrorResponse
+import com.recap.api.util.desc
+import com.recap.api.util.fieldsOf
+
+val errorResponseFields =
+    fieldsOf(
+        ErrorResponse::code desc "에러 코드",
+        ErrorResponse::message desc "에러 메세지"
+    )

--- a/api/src/testFixtures/kotlin/com/recap/api/util/WebTestClientUtils.kt
+++ b/api/src/testFixtures/kotlin/com/recap/api/util/WebTestClientUtils.kt
@@ -1,5 +1,6 @@
 package com.recap.api.util
 
+import com.recap.api.global.dto.ErrorResponse
 import io.kotest.matchers.shouldBe
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient.BodySpec
@@ -13,3 +14,5 @@ fun ResponseSpec.expectStatus(status: HttpStatus): ResponseSpec =
 inline fun <reified T : Any> ResponseSpec.expectBody(body: T): BodySpec<T, *> =
     expectBody<T>()
         .consumeWith { it.responseBody shouldBe body }
+
+fun ResponseSpec.expectError(): BodySpec<ErrorResponse, *> = expectBody<ErrorResponse>()

--- a/core/src/main/kotlin/com/recap/core/global/exception/ServerException.kt
+++ b/core/src/main/kotlin/com/recap/core/global/exception/ServerException.kt
@@ -1,0 +1,6 @@
+package com.recap.core.global.exception
+
+abstract class ServerException(
+    val status: Int,
+    override val message: String
+) : RuntimeException(message)


### PR DESCRIPTION
## 작업 내용

- 전역 예외 처리 핸들러 구현
- 공통 예외 및 응답 DTO 추가
- Spring Security 설정

## 참고
 
- 인증 및 인가 예외 처리 구현하는 김에 Spring Security도 설정했습니다.

## 관련 이슈

- close #6