### PR TITLE
[#15] 토큰 리프레시 기능 구현

### DIFF
--- a/api/src/main/kotlin/com/recap/api/domain/auth/controller/AuthController.kt
+++ b/api/src/main/kotlin/com/recap/api/domain/auth/controller/AuthController.kt
@@ -1,7 +1,9 @@
 package com.recap.api.domain.auth.controller
 
 import com.recap.api.domain.auth.dto.request.LoginRequest
+import com.recap.api.domain.auth.dto.request.RefreshRequest
 import com.recap.api.domain.auth.dto.response.LoginResponse
+import com.recap.api.domain.auth.dto.response.RefreshResponse
 import com.recap.core.domain.auth.service.AuthService
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PostMapping
@@ -16,11 +18,21 @@ class AuthController(
 ) {
     @PostMapping("/login")
     fun login(
-        @RequestBody
         @Valid
+        @RequestBody
         request: LoginRequest
     ): LoginResponse =
         authService
             .login(request.toCommand())
             .let { LoginResponse.from(it) }
+
+    @PostMapping("/refresh")
+    fun refresh(
+        @Valid
+        @RequestBody
+        request: RefreshRequest
+    ): RefreshResponse =
+        authService
+            .refresh(request.toCommand())
+            .let { RefreshResponse.from(it) }
 }

--- a/api/src/main/kotlin/com/recap/api/domain/auth/dto/request/RefreshRequest.kt
+++ b/api/src/main/kotlin/com/recap/api/domain/auth/dto/request/RefreshRequest.kt
@@ -1,0 +1,11 @@
+package com.recap.api.domain.auth.dto.request
+
+import com.recap.core.domain.auth.dto.command.RefreshCommand
+import jakarta.validation.constraints.NotBlank
+
+data class RefreshRequest(
+    @field:NotBlank
+    val refreshToken: String
+) {
+    fun toCommand(): RefreshCommand = RefreshCommand(refreshToken = refreshToken)
+}

--- a/api/src/main/kotlin/com/recap/api/domain/auth/dto/response/RefreshResponse.kt
+++ b/api/src/main/kotlin/com/recap/api/domain/auth/dto/response/RefreshResponse.kt
@@ -1,0 +1,18 @@
+package com.recap.api.domain.auth.dto.response
+
+import com.recap.core.domain.auth.dto.result.RefreshResult
+
+data class RefreshResponse(
+    val accessToken: String,
+    val refreshToken: String
+) {
+    companion object {
+        fun from(result: RefreshResult): RefreshResponse =
+            with(result) {
+                RefreshResponse(
+                    accessToken = accessToken,
+                    refreshToken = refreshToken
+                )
+            }
+    }
+}

--- a/api/src/main/kotlin/com/recap/api/global/security/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/recap/api/global/security/JwtAuthenticationFilter.kt
@@ -25,7 +25,7 @@ class JwtAuthenticationFilter(
         request
             .getHeader(HttpHeaders.AUTHORIZATION)
             ?.run {
-                runCatching { jwtProvider.getPayload(getBearerToken()) }
+                runCatching { jwtProvider.extractPayload(getBearerToken()) }
                     .onSuccess { SecurityContextHolder.getContext().authentication = RecapAuthentication.from(it) }
                     .onFailure { if (it !is JwtException) throw it }
             }

--- a/api/src/test/kotlin/com/recap/api/domain/auth/AuthControllerTest.kt
+++ b/api/src/test/kotlin/com/recap/api/domain/auth/AuthControllerTest.kt
@@ -4,17 +4,21 @@ import com.ninjasquad.springmockk.MockkBean
 import com.recap.api.common.ControllerTest
 import com.recap.api.domain.auth.controller.AuthController
 import com.recap.api.domain.auth.dto.response.LoginResponse
+import com.recap.api.domain.auth.dto.response.RefreshResponse
 import com.recap.api.fixture.createLoginRequest
-import com.recap.api.snippet.errorResponseFields
-import com.recap.api.snippet.loginRequestFields
-import com.recap.api.snippet.loginResponseFields
+import com.recap.api.fixture.createRefreshRequest
+import com.recap.api.snippet.*
 import com.recap.api.util.document
 import com.recap.api.util.expectBody
 import com.recap.api.util.expectError
 import com.recap.api.util.expectStatus
+import com.recap.core.domain.auth.exception.InvalidAuthenticationException
 import com.recap.core.domain.auth.exception.InvalidOAuthTokenException
+import com.recap.core.domain.auth.exception.RefreshTokenNotFoundException
 import com.recap.core.domain.auth.service.AuthService
+import com.recap.core.domain.user.exception.UserNotFoundException
 import com.recap.core.fixture.createLoginResult
+import com.recap.core.fixture.createRefreshResult
 import io.mockk.every
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 
@@ -58,6 +62,76 @@ class AuthControllerTest : ControllerTest() {
                         .expectError()
                         .document("로그인 실패(401)") {
                             requestBody(loginRequestFields)
+                            responseBody(errorResponseFields)
+                        }
+                }
+            }
+        }
+
+        describe("refresh()는") {
+            val request =
+                webClient
+                    .post()
+                    .uri("/auth/refresh")
+                    .bodyValue(createRefreshRequest())
+
+            context("유효한 요청이 주어진 경우") {
+                val result = createRefreshResult()
+
+                every { authService.refresh(any()) } returns result
+
+                it("상태 코드 200과 RefreshResponse를 반환한다.") {
+                    request
+                        .exchange()
+                        .expectStatus(200)
+                        .expectBody(RefreshResponse.from(result))
+                        .document("토큰 리프레시 성공(200)") {
+                            requestBody(refreshRequestFields)
+                            responseBody(refreshResponseFields)
+                        }
+                }
+            }
+
+            context("유효하지 않은 리프레시 토큰이 주어진 경우") {
+                every { authService.refresh(any()) } throws InvalidAuthenticationException()
+
+                it("상태 코드 401과 ErrorResponse를 반환한다.") {
+                    request
+                        .exchange()
+                        .expectStatus(401)
+                        .expectError()
+                        .document("토큰 리프레시 실패(401)") {
+                            requestBody(refreshRequestFields)
+                            responseBody(errorResponseFields)
+                        }
+                }
+            }
+
+            context("로그아웃한 사용자의 리프레시 토큰이 주어진 경우") {
+                every { authService.refresh(any()) } throws RefreshTokenNotFoundException()
+
+                it("상태 코드 404와 ErrorResponse를 반환한다.") {
+                    request
+                        .exchange()
+                        .expectStatus(404)
+                        .expectError()
+                        .document("토큰 리프레시 실패(404 - 1)") {
+                            requestBody(refreshRequestFields)
+                            responseBody(errorResponseFields)
+                        }
+                }
+            }
+
+            context("탈퇴한 사용자의 유효한 리프레시 토큰이 주어진 경우") {
+                every { authService.refresh(any()) } throws UserNotFoundException()
+
+                it("상태 코드 404와 ErrorResponse를 반환한다.") {
+                    request
+                        .exchange()
+                        .expectStatus(404)
+                        .expectError()
+                        .document("토큰 리프레시 실패(404 - 2)") {
+                            requestBody(refreshRequestFields)
                             responseBody(errorResponseFields)
                         }
                 }

--- a/api/src/test/kotlin/com/recap/api/domain/auth/AuthControllerTest.kt
+++ b/api/src/test/kotlin/com/recap/api/domain/auth/AuthControllerTest.kt
@@ -11,6 +11,7 @@ import com.recap.api.snippet.loginResponseFields
 import com.recap.api.util.document
 import com.recap.api.util.expectBody
 import com.recap.api.util.expectError
+import com.recap.api.util.expectStatus
 import com.recap.core.domain.auth.exception.InvalidOAuthTokenException
 import com.recap.core.domain.auth.service.AuthService
 import com.recap.core.fixture.createLoginResult
@@ -24,22 +25,22 @@ class AuthControllerTest : ControllerTest() {
 
     init {
         describe("login()은") {
-            val uri = "/api/v1/auth/login"
-            val request = createLoginRequest()
-            val result = createLoginResult()
+            val request =
+                webClient
+                    .post()
+                    .uri("/auth/login")
+                    .bodyValue(createLoginRequest())
 
-            context("유효한 OAuth2 토큰이 주어진 경우") {
-                every { authService.login(request.toCommand()) } returns result
+            context("유효한 요청이 주어진 경우") {
+                val result = createLoginResult()
+
+                every { authService.login(any()) } returns result
 
                 it("상태 코드 200과 LoginResponse를 반환한다.") {
-                    webClient
-                        .post()
-                        .uri(uri)
-                        .bodyValue(request)
+                    request
                         .exchange()
-                        .expectStatus()
-                        .isOk
-                        .expectBody<LoginResponse>(LoginResponse.from(result))
+                        .expectStatus(200)
+                        .expectBody(LoginResponse.from(result))
                         .document("로그인 성공(200)") {
                             requestBody(loginRequestFields)
                             responseBody(loginResponseFields)
@@ -48,16 +49,12 @@ class AuthControllerTest : ControllerTest() {
             }
 
             context("유효하지 않은 OAuth2 토큰이 주어진 경우") {
-                every { authService.login(request.toCommand()) } throws InvalidOAuthTokenException()
+                every { authService.login(any()) } throws InvalidOAuthTokenException()
 
                 it("상태 코드 401과 ErrorResponse를 반환한다.") {
-                    webClient
-                        .post()
-                        .uri(uri)
-                        .bodyValue(request)
+                    request
                         .exchange()
-                        .expectStatus()
-                        .isUnauthorized
+                        .expectStatus(401)
                         .expectError()
                         .document("로그인 실패(401)") {
                             requestBody(loginRequestFields)

--- a/api/src/testFixtures/kotlin/com/recap/api/common/ControllerTest.kt
+++ b/api/src/testFixtures/kotlin/com/recap/api/common/ControllerTest.kt
@@ -11,7 +11,9 @@ import org.springframework.test.web.servlet.client.MockMvcWebTestClient
 import org.springframework.web.context.WebApplicationContext
 
 @AutoConfigureRestDocs
-abstract class ControllerTest : DescribeSpec() {
+abstract class ControllerTest(
+    private val version: Int = 1
+) : DescribeSpec() {
     @Autowired
     private lateinit var webApplicationContext: WebApplicationContext
 
@@ -22,6 +24,7 @@ abstract class ControllerTest : DescribeSpec() {
         MockMvcWebTestClient
             .bindToApplicationContext(webApplicationContext)
             .configureClient()
+            .baseUrl("/api/v$version")
             .filter(WebTestClientRestDocumentation.documentationConfiguration(restDocumentationContextProvider))
             .build()
     }

--- a/api/src/testFixtures/kotlin/com/recap/api/fixture/AuthFixtures.kt
+++ b/api/src/testFixtures/kotlin/com/recap/api/fixture/AuthFixtures.kt
@@ -1,6 +1,7 @@
 package com.recap.api.fixture
 
 import com.recap.api.domain.auth.dto.request.LoginRequest
+import com.recap.api.domain.auth.dto.request.RefreshRequest
 import com.recap.core.domain.user.entity.Provider
 import com.recap.core.fixture.PROVIDER
 import com.recap.core.fixture.TOKEN
@@ -13,3 +14,5 @@ fun createLoginRequest(
         oAuthToken = oAuthToken,
         provider = provider
     )
+
+fun createRefreshRequest(refreshToken: String = TOKEN): RefreshRequest = RefreshRequest(refreshToken = refreshToken)

--- a/api/src/testFixtures/kotlin/com/recap/api/snippet/AuthSnippets.kt
+++ b/api/src/testFixtures/kotlin/com/recap/api/snippet/AuthSnippets.kt
@@ -1,7 +1,9 @@
 package com.recap.api.snippet
 
 import com.recap.api.domain.auth.dto.request.LoginRequest
+import com.recap.api.domain.auth.dto.request.RefreshRequest
 import com.recap.api.domain.auth.dto.response.LoginResponse
+import com.recap.api.domain.auth.dto.response.RefreshResponse
 import com.recap.api.util.desc
 import com.recap.api.util.fieldsOf
 
@@ -11,8 +13,19 @@ val loginRequestFields =
         LoginRequest::provider desc "OAuth2 제공자"
     )
 
+val refreshRequestFields =
+    fieldsOf(
+        RefreshRequest::refreshToken desc "리프레시 토큰"
+    )
+
 val loginResponseFields =
     fieldsOf(
         LoginResponse::accessToken desc "액세스 토큰",
         LoginResponse::refreshToken desc "리프레시 토큰"
+    )
+
+val refreshResponseFields =
+    fieldsOf(
+        RefreshResponse::accessToken desc "액세스 토큰",
+        RefreshResponse::refreshToken desc "리프레시 토큰"
     )

--- a/api/src/testFixtures/kotlin/com/recap/api/util/WebTestClientUtils.kt
+++ b/api/src/testFixtures/kotlin/com/recap/api/util/WebTestClientUtils.kt
@@ -2,12 +2,11 @@ package com.recap.api.util
 
 import com.recap.api.global.dto.ErrorResponse
 import io.kotest.matchers.shouldBe
-import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient.BodySpec
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
 import org.springframework.test.web.reactive.server.expectBody
 
-fun ResponseSpec.expectStatus(status: HttpStatus): ResponseSpec =
+fun ResponseSpec.expectStatus(status: Int): ResponseSpec =
     expectStatus()
         .isEqualTo(status)
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,6 +11,7 @@ allOpen {
 dependencies {
     implementation(libs.spring.web)
     implementation(libs.spring.data.jpa)
+    implementation(libs.spring.data.redis)
     implementation(libs.hypersistence.utils)
     implementation(libs.bundles.jwt)
     runtimeOnly(libs.mysql.connector)

--- a/core/src/main/kotlin/com/recap/core/domain/auth/dto/command/RefreshCommand.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/dto/command/RefreshCommand.kt
@@ -1,0 +1,5 @@
+package com.recap.core.domain.auth.dto.command
+
+data class RefreshCommand(
+    val refreshToken: String
+)

--- a/core/src/main/kotlin/com/recap/core/domain/auth/dto/result/RefreshResult.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/dto/result/RefreshResult.kt
@@ -1,0 +1,6 @@
+package com.recap.core.domain.auth.dto.result
+
+data class RefreshResult(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/core/src/main/kotlin/com/recap/core/domain/auth/entity/RefreshToken.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/entity/RefreshToken.kt
@@ -1,0 +1,17 @@
+package com.recap.core.domain.auth.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+import java.time.Duration
+
+@RedisHash
+class RefreshToken(
+    @Id
+    val userId: Long,
+    val content: String,
+    expiration: Duration
+) {
+    @TimeToLive
+    private val ttl = expiration.toSeconds()
+}

--- a/core/src/main/kotlin/com/recap/core/domain/auth/exception/InvalidAuthenticationException.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/exception/InvalidAuthenticationException.kt
@@ -1,0 +1,7 @@
+package com.recap.core.domain.auth.exception
+
+import com.recap.core.global.exception.ServerException
+
+class InvalidAuthenticationException(
+    override val message: String = "유효하지 않은 인증 토큰입니다."
+) : ServerException(status = 401, message)

--- a/core/src/main/kotlin/com/recap/core/domain/auth/exception/RefreshTokenNotFoundException.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/exception/RefreshTokenNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.recap.core.domain.auth.exception
+
+import com.recap.core.global.exception.ServerException
+
+class RefreshTokenNotFoundException(
+    override val message: String = "존재하지 않는 리프레시 토큰입니다."
+) : ServerException(status = 404, message)

--- a/core/src/main/kotlin/com/recap/core/domain/auth/repository/RefreshTokenRepository.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/repository/RefreshTokenRepository.kt
@@ -5,6 +5,4 @@ import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface RefreshTokenRepository : CrudRepository<RefreshToken, Long> {
-    fun findByUserId(userId: Long): RefreshToken?
-}
+interface RefreshTokenRepository : CrudRepository<RefreshToken, Long>

--- a/core/src/main/kotlin/com/recap/core/domain/auth/repository/RefreshTokenRepository.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/repository/RefreshTokenRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface RefreshTokenRepository : CrudRepository<RefreshToken, Long>
+interface RefreshTokenRepository : CrudRepository<RefreshToken, Long> {
+    fun findByUserId(userId: Long): RefreshToken?
+}

--- a/core/src/main/kotlin/com/recap/core/domain/auth/repository/RefreshTokenRepository.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/repository/RefreshTokenRepository.kt
@@ -1,0 +1,8 @@
+package com.recap.core.domain.auth.repository
+
+import com.recap.core.domain.auth.entity.RefreshToken
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RefreshTokenRepository : CrudRepository<RefreshToken, Long>

--- a/core/src/main/kotlin/com/recap/core/domain/auth/service/AuthService.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/service/AuthService.kt
@@ -2,13 +2,19 @@ package com.recap.core.domain.auth.service
 
 import com.recap.core.domain.auth.client.OAuthClient
 import com.recap.core.domain.auth.dto.command.LoginCommand
+import com.recap.core.domain.auth.dto.command.RefreshCommand
 import com.recap.core.domain.auth.dto.result.LoginResult
+import com.recap.core.domain.auth.dto.result.RefreshResult
 import com.recap.core.domain.auth.entity.RefreshToken
+import com.recap.core.domain.auth.exception.InvalidAuthenticationException
+import com.recap.core.domain.auth.exception.RefreshTokenNotFoundException
 import com.recap.core.domain.auth.repository.RefreshTokenRepository
 import com.recap.core.domain.user.entity.User
+import com.recap.core.domain.user.exception.UserNotFoundException
 import com.recap.core.domain.user.repository.UserRepository
 import com.recap.core.global.jwt.JwtProvider
 import com.recap.core.global.properties.JwtProperties
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -36,26 +42,51 @@ class AuthService(
                         email = getOAuthUserResponse.email,
                         provider = provider
                     )
-
-            userRepository.save(user)
-
-            val accessToken = jwtProvider.createToken(jwtProperties.accessTokenExpiration, user)
-            val refreshToken =
-                jwtProvider
-                    .createToken(jwtProperties.refreshTokenExpiration, user)
-                    .also {
-                        refreshTokenRepository.save(
-                            RefreshToken(
-                                userId = user.id!!,
-                                content = it,
-                                expiration = jwtProperties.refreshTokenExpiration
-                            )
-                        )
-                    }
+            val (accessToken, refreshToken) =
+                userRepository
+                    .save(user)
+                    .createTokens()
 
             LoginResult(
                 accessToken = accessToken,
                 refreshToken = refreshToken
             )
         }
+
+    @Transactional(readOnly = true)
+    fun refresh(command: RefreshCommand): RefreshResult =
+        with(command) {
+            val userId = jwtProvider.extractUserId(refreshToken)
+
+            refreshTokenRepository
+                .findByUserId(userId)
+                ?.apply { if (content != refreshToken) throw InvalidAuthenticationException() }
+                ?: throw RefreshTokenNotFoundException()
+
+            val user = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException()
+            val (accessToken, refreshToken) = user.createTokens()
+
+            return RefreshResult(
+                accessToken = accessToken,
+                refreshToken = refreshToken
+            )
+        }
+
+    private fun User.createTokens(): Pair<String, String> {
+        val accessToken = jwtProvider.createToken(jwtProperties.accessTokenExpiration, this)
+        val refreshToken =
+            jwtProvider
+                .createToken(jwtProperties.refreshTokenExpiration, this)
+                .also {
+                    refreshTokenRepository.save(
+                        RefreshToken(
+                            userId = id!!,
+                            content = it,
+                            expiration = jwtProperties.refreshTokenExpiration
+                        )
+                    )
+                }
+
+        return accessToken to refreshToken
+    }
 }

--- a/core/src/main/kotlin/com/recap/core/domain/auth/service/AuthService.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/service/AuthService.kt
@@ -3,6 +3,8 @@ package com.recap.core.domain.auth.service
 import com.recap.core.domain.auth.client.OAuthClient
 import com.recap.core.domain.auth.dto.command.LoginCommand
 import com.recap.core.domain.auth.dto.result.LoginResult
+import com.recap.core.domain.auth.entity.RefreshToken
+import com.recap.core.domain.auth.repository.RefreshTokenRepository
 import com.recap.core.domain.user.entity.User
 import com.recap.core.domain.user.repository.UserRepository
 import com.recap.core.global.jwt.JwtProvider
@@ -13,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class AuthService(
     private val userRepository: UserRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
     private val oAuthClients: List<OAuthClient>,
     private val jwtProvider: JwtProvider,
     private val jwtProperties: JwtProperties
@@ -37,7 +40,18 @@ class AuthService(
             userRepository.save(user)
 
             val accessToken = jwtProvider.createToken(jwtProperties.accessTokenExpiration, user)
-            val refreshToken = jwtProvider.createToken(jwtProperties.refreshTokenExpiration, user)
+            val refreshToken =
+                jwtProvider
+                    .createToken(jwtProperties.refreshTokenExpiration, user)
+                    .also {
+                        refreshTokenRepository.save(
+                            RefreshToken(
+                                userId = user.id!!,
+                                content = it,
+                                expiration = jwtProperties.refreshTokenExpiration
+                            )
+                        )
+                    }
 
             LoginResult(
                 accessToken = accessToken,

--- a/core/src/main/kotlin/com/recap/core/domain/auth/service/AuthService.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/service/AuthService.kt
@@ -14,9 +14,9 @@ import com.recap.core.domain.user.exception.UserNotFoundException
 import com.recap.core.domain.user.repository.UserRepository
 import com.recap.core.global.jwt.JwtProvider
 import com.recap.core.global.properties.JwtProperties
+import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class AuthService(
@@ -53,7 +53,6 @@ class AuthService(
             )
         }
 
-    @Transactional(readOnly = true)
     fun refresh(command: RefreshCommand): RefreshResult =
         with(command) {
             val userId = jwtProvider.extractUserId(refreshToken)

--- a/core/src/main/kotlin/com/recap/core/domain/auth/service/AuthService.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/service/AuthService.kt
@@ -59,8 +59,14 @@ class AuthService(
             val userId = jwtProvider.extractUserId(refreshToken)
 
             refreshTokenRepository
-                .findByUserId(userId)
-                ?.apply { if (content != refreshToken) throw InvalidAuthenticationException() }
+                .findByIdOrNull(userId)
+                ?.apply {
+                    if (content != refreshToken) {
+                        refreshTokenRepository.deleteById(userId)
+
+                        throw InvalidAuthenticationException()
+                    }
+                }
                 ?: throw RefreshTokenNotFoundException()
 
             val user = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException()

--- a/core/src/main/kotlin/com/recap/core/domain/auth/service/AuthService.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/auth/service/AuthService.kt
@@ -14,9 +14,9 @@ import com.recap.core.domain.user.exception.UserNotFoundException
 import com.recap.core.domain.user.repository.UserRepository
 import com.recap.core.global.jwt.JwtProvider
 import com.recap.core.global.properties.JwtProperties
-import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class AuthService(

--- a/core/src/main/kotlin/com/recap/core/domain/user/exception/UserNotFoundException.kt
+++ b/core/src/main/kotlin/com/recap/core/domain/user/exception/UserNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.recap.core.domain.user.exception
+
+import com.recap.core.global.exception.ServerException
+
+class UserNotFoundException(
+    override val message: String = "존재하지 않는 사용자입니다."
+) : ServerException(status = 404, message)

--- a/core/src/main/kotlin/com/recap/core/global/config/RedisConfiguration.kt
+++ b/core/src/main/kotlin/com/recap/core/global/config/RedisConfiguration.kt
@@ -1,0 +1,8 @@
+package com.recap.core.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
+
+@Configuration
+@EnableRedisRepositories(basePackages = ["com.recap.core.domain.auth"])
+class RedisConfiguration

--- a/core/src/main/kotlin/com/recap/core/global/jwt/JwtProvider.kt
+++ b/core/src/main/kotlin/com/recap/core/global/jwt/JwtProvider.kt
@@ -45,7 +45,7 @@ class JwtProvider(
             .compact()
     }
 
-    fun getPayload(token: String): Map<String, *> =
+    fun extractPayload(token: String): Map<String, *> =
         Jwts
             .parser()
             .verifyWith(jwtProperties.secretKey)

--- a/core/src/main/kotlin/com/recap/core/global/jwt/JwtProvider.kt
+++ b/core/src/main/kotlin/com/recap/core/global/jwt/JwtProvider.kt
@@ -1,7 +1,9 @@
 package com.recap.core.global.jwt
 
+import com.recap.core.domain.auth.exception.InvalidAuthenticationException
 import com.recap.core.domain.user.entity.User
 import com.recap.core.global.properties.JwtProperties
+import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts
 import org.springframework.stereotype.Component
 import java.time.Duration
@@ -27,6 +29,15 @@ class JwtProvider(
                     ::roles.name to roles.joinToString(",")
                 )
             )
+        }
+
+    fun extractUserId(token: String): Long =
+        try {
+            extractPayload(token)
+                .run { get(User::id.name) as String }
+                .toLong()
+        } catch (exception: JwtException) {
+            throw InvalidAuthenticationException()
         }
 
     fun createToken(

--- a/core/src/test/kotlin/com/recap/core/domain/auth/service/AuthServiceTest.kt
+++ b/core/src/test/kotlin/com/recap/core/domain/auth/service/AuthServiceTest.kt
@@ -14,9 +14,7 @@ import com.recap.core.global.properties.JwtProperties
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
+import io.mockk.*
 import org.springframework.data.repository.findByIdOrNull
 
 class AuthServiceTest : BehaviorSpec() {
@@ -128,7 +126,7 @@ class AuthServiceTest : BehaviorSpec() {
             every { refreshTokenRepository.save(any()) } returns refreshToken
 
             And("리프레시 토큰이 로그인 시점에 발급된 리프레시 토큰과 같은 경우") {
-                every { refreshTokenRepository.findByUserId(any()) } returns refreshToken
+                every { refreshTokenRepository.findByIdOrNull(any()) } returns refreshToken
 
                 When("토큰 리프레시를 시도하면") {
                     val result = authService.refresh(command)
@@ -142,12 +140,14 @@ class AuthServiceTest : BehaviorSpec() {
             And("리프레시 토큰이 로그인 시점에 발급된 리프레시 토큰과 다른 경우") {
                 val storedRefreshToken = "dsadadasdsdsdsdsdsdsadsadads"
 
-                every { refreshTokenRepository.findByUserId(any()) } returns
+                every { refreshTokenRepository.findByIdOrNull(any()) } returns
                     createRefreshToken(content = storedRefreshToken)
+                every { refreshTokenRepository.deleteById(any()) } just runs
 
                 When("토큰 리프레시를 시도하면") {
-                    Then("예외가 발생한다.") {
+                    Then("저장된 리프레시 토큰이 삭제되고 예외가 발생한다.") {
                         shouldThrow<InvalidAuthenticationException> { authService.refresh(command) }
+                        verify { refreshTokenRepository.deleteById(any()) }
                     }
                 }
             }
@@ -158,7 +158,7 @@ class AuthServiceTest : BehaviorSpec() {
             val refreshToken = createRefreshToken()
 
             every { userRepository.findByIdOrNull(any()) } returns null
-            every { refreshTokenRepository.findByUserId(any()) } returns refreshToken
+            every { refreshTokenRepository.findByIdOrNull(any()) } returns refreshToken
 
             When("토큰 리프레시를 시도하면") {
                 Then("예외가 발생한다.") {
@@ -172,7 +172,7 @@ class AuthServiceTest : BehaviorSpec() {
             val user = createUser()
 
             every { userRepository.findByIdOrNull(any()) } returns user
-            every { refreshTokenRepository.findByUserId(any()) } returns null
+            every { refreshTokenRepository.findByIdOrNull(any()) } returns null
 
             When("토큰 리프레시를 시도하면") {
                 Then("예외가 발생한다.") {

--- a/core/src/test/kotlin/com/recap/core/domain/auth/service/AuthServiceTest.kt
+++ b/core/src/test/kotlin/com/recap/core/domain/auth/service/AuthServiceTest.kt
@@ -1,9 +1,12 @@
 package com.recap.core.domain.auth.service
 
 import com.recap.core.domain.auth.client.OAuthClient
+import com.recap.core.domain.auth.exception.InvalidAuthenticationException
 import com.recap.core.domain.auth.exception.InvalidOAuthTokenException
+import com.recap.core.domain.auth.exception.RefreshTokenNotFoundException
 import com.recap.core.domain.auth.repository.RefreshTokenRepository
 import com.recap.core.domain.user.entity.User
+import com.recap.core.domain.user.exception.UserNotFoundException
 import com.recap.core.domain.user.repository.UserRepository
 import com.recap.core.fixture.*
 import com.recap.core.global.jwt.JwtProvider
@@ -14,6 +17,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import org.springframework.data.repository.findByIdOrNull
 
 class AuthServiceTest : BehaviorSpec() {
     private val userRepository = mockk<UserRepository>()
@@ -23,6 +27,7 @@ class AuthServiceTest : BehaviorSpec() {
         mockk<JwtProvider>()
             .apply {
                 every { createToken(any(), any<User>()) } returns TOKEN
+                every { extractUserId(any()) } returns ID
             }
     private val jwtProperties =
         mockk<JwtProperties>()
@@ -110,6 +115,80 @@ class AuthServiceTest : BehaviorSpec() {
             When("로그인을 시도하면") {
                 Then("예외가 발생한다.") {
                     shouldThrow<InvalidOAuthTokenException> { authService.login(command) }
+                }
+            }
+        }
+
+        Given("사용자가 유효한 리프레시 토큰을 가지고 있고") {
+            val command = createRefreshCommand()
+            val user = createUser()
+            val refreshToken = createRefreshToken()
+
+            every { userRepository.findByIdOrNull(any()) } returns user
+            every { refreshTokenRepository.save(any()) } returns refreshToken
+
+            And("리프레시 토큰이 로그인 시점에 발급된 리프레시 토큰과 같은 경우") {
+                every { refreshTokenRepository.findByUserId(any()) } returns refreshToken
+
+                When("토큰 리프레시를 시도하면") {
+                    val result = authService.refresh(command)
+
+                    Then("리프레시 토큰이 재발급된다.") {
+                        result shouldBe createRefreshResult()
+                    }
+                }
+            }
+
+            And("리프레시 토큰이 로그인 시점에 발급된 리프레시 토큰과 다른 경우") {
+                val storedRefreshToken = "dsadadasdsdsdsdsdsdsadsadads"
+
+                every { refreshTokenRepository.findByUserId(any()) } returns
+                    createRefreshToken(content = storedRefreshToken)
+
+                When("토큰 리프레시를 시도하면") {
+                    Then("예외가 발생한다.") {
+                        shouldThrow<InvalidAuthenticationException> { authService.refresh(command) }
+                    }
+                }
+            }
+        }
+
+        Given("탈퇴한 사용자가 유효한 리프레시 토큰을 가진 경우") {
+            val command = createRefreshCommand()
+            val refreshToken = createRefreshToken()
+
+            every { userRepository.findByIdOrNull(any()) } returns null
+            every { refreshTokenRepository.findByUserId(any()) } returns refreshToken
+
+            When("토큰 리프레시를 시도하면") {
+                Then("예외가 발생한다.") {
+                    shouldThrow<UserNotFoundException> { authService.refresh(command) }
+                }
+            }
+        }
+
+        Given("로그아웃한 사용자가 유효한 리프레시 토큰을 가진 경우") {
+            val command = createRefreshCommand()
+            val user = createUser()
+
+            every { userRepository.findByIdOrNull(any()) } returns user
+            every { refreshTokenRepository.findByUserId(any()) } returns null
+
+            When("토큰 리프레시를 시도하면") {
+                Then("예외가 발생한다.") {
+                    shouldThrow<RefreshTokenNotFoundException> { authService.refresh(command) }
+                }
+            }
+        }
+
+        Given("사용자가 유효하지 않은 리프레시 토큰을 가진 경우") {
+            val command = createRefreshCommand()
+
+            every { jwtProvider.extractUserId(any()) } throws InvalidAuthenticationException()
+
+            When("토큰 리프레시를 시도하면") {
+                Then("예외가 발생한다.") {
+                    shouldThrow<InvalidAuthenticationException> { authService.refresh(command) }
                 }
             }
         }

--- a/core/src/test/kotlin/com/recap/core/domain/auth/service/AuthServiceTest.kt
+++ b/core/src/test/kotlin/com/recap/core/domain/auth/service/AuthServiceTest.kt
@@ -1,7 +1,8 @@
 package com.recap.core.domain.auth.service
 
-import com.recap.core.domain.auth.client.GoogleClient
+import com.recap.core.domain.auth.client.OAuthClient
 import com.recap.core.domain.auth.exception.InvalidOAuthTokenException
+import com.recap.core.domain.auth.repository.RefreshTokenRepository
 import com.recap.core.domain.user.entity.User
 import com.recap.core.domain.user.repository.UserRepository
 import com.recap.core.fixture.*
@@ -12,45 +13,89 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 
 class AuthServiceTest : BehaviorSpec() {
     private val userRepository = mockk<UserRepository>()
-    private val oAuthClient = mockk<GoogleClient>()
-    val jwtProvider =
+    private val refreshTokenRepository = mockk<RefreshTokenRepository>()
+    private val oAuthClient = mockk<OAuthClient>()
+    private val jwtProvider =
         mockk<JwtProvider>()
             .apply {
                 every { createToken(any(), any<User>()) } returns TOKEN
             }
-    val jwtProperties =
+    private val jwtProperties =
         mockk<JwtProperties>()
             .apply {
                 every { accessTokenExpiration } returns EXPIRATION
                 every { refreshTokenExpiration } returns EXPIRATION
             }
-
     private val authService =
         AuthService(
             userRepository = userRepository,
+            refreshTokenRepository = refreshTokenRepository,
             oAuthClients = listOf(oAuthClient),
             jwtProvider = jwtProvider,
             jwtProperties = jwtProperties
         )
 
     init {
-        Given("사용자가 유효한 OAuth2 토큰을 가진 경우") {
+        Given("가입한 사용자가 유효한 OAuth2 토큰을 가지고 있고") {
             val command = createLoginCommand()
             val user = createUser()
+            val refreshToken = createRefreshToken()
+            val userSlot = slot<User>()
+
+            every { userRepository.findBySocialIdAndProvider(any(), any()) } returns user
+            every { userRepository.save(capture(userSlot)) } returns user
+            every { refreshTokenRepository.save(any()) } returns refreshToken
+            every { oAuthClient.provider } returns command.provider
+
+            And("소셜 이메일이 사용자 이메일과 같은 경우") {
+                every { oAuthClient.getOAuthUserByToken(any()) } returns createGetOAuthUserResponse()
+
+                When("로그인을 시도하면") {
+                    val result = authService.login(command)
+
+                    Then("로그인 처리가 된다.") {
+                        result shouldBe createLoginResult()
+                    }
+                }
+            }
+
+            And("소셜 이메일이 사용자 이메일과 다른 경우") {
+                val changedEmail = "1117mg@github.com"
+
+                every { oAuthClient.getOAuthUserByToken(any()) } returns
+                    createGetOAuthUserResponse(email = changedEmail)
+
+                When("로그인을 시도하면") {
+                    val result = authService.login(command)
+
+                    Then("사용자 이메일이 변경되고 로그인 처리가 된다.") {
+                        userSlot.captured.email shouldBe changedEmail
+                        result shouldBe createLoginResult()
+                    }
+                }
+            }
+        }
+
+        Given("가입하지 않은 사용자가 유효한 OAuth2 토큰을 가지고 있는 경우") {
+            val command = createLoginCommand()
+            val user = createUser()
+            val refreshToken = createRefreshToken()
             val getOAuthUserResponse = createGetOAuthUserResponse()
 
-            every { userRepository.findBySocialIdAndProvider(user.socialId, user.provider) } returns user
-            every { userRepository.save(user) } returns user
+            every { userRepository.findBySocialIdAndProvider(any(), any()) } returns null
+            every { userRepository.save(any()) } returns user
+            every { refreshTokenRepository.save(any()) } returns refreshToken
             every { oAuthClient.provider } returns command.provider
-            every { oAuthClient.getOAuthUserByToken(command.oAuthToken) } returns getOAuthUserResponse
+            every { oAuthClient.getOAuthUserByToken(any()) } returns getOAuthUserResponse
 
             When("로그인을 시도하면") {
                 val result = authService.login(command)
 
-                Then("로그인 처리가 된다.") {
+                Then("회원가입과 함께 로그인 처리가 된다.") {
                     result shouldBe createLoginResult()
                 }
             }
@@ -60,7 +105,7 @@ class AuthServiceTest : BehaviorSpec() {
             val command = createLoginCommand()
 
             every { oAuthClient.provider } returns command.provider
-            every { oAuthClient.getOAuthUserByToken(command.oAuthToken) } throws InvalidOAuthTokenException()
+            every { oAuthClient.getOAuthUserByToken(any()) } throws InvalidOAuthTokenException()
 
             When("로그인을 시도하면") {
                 Then("예외가 발생한다.") {

--- a/core/src/test/kotlin/com/recap/core/domain/auth/service/AuthServiceTest.kt
+++ b/core/src/test/kotlin/com/recap/core/domain/auth/service/AuthServiceTest.kt
@@ -88,9 +88,10 @@ class AuthServiceTest : BehaviorSpec() {
             val user = createUser()
             val refreshToken = createRefreshToken()
             val getOAuthUserResponse = createGetOAuthUserResponse()
+            val userSlot = slot<User>()
 
             every { userRepository.findBySocialIdAndProvider(any(), any()) } returns null
-            every { userRepository.save(any()) } returns user
+            every { userRepository.save(capture(userSlot)) } returns user
             every { refreshTokenRepository.save(any()) } returns refreshToken
             every { oAuthClient.provider } returns command.provider
             every { oAuthClient.getOAuthUserByToken(any()) } returns getOAuthUserResponse
@@ -99,6 +100,7 @@ class AuthServiceTest : BehaviorSpec() {
                 val result = authService.login(command)
 
                 Then("회원가입과 함께 로그인 처리가 된다.") {
+                    userSlot.captured.id shouldBe null
                     result shouldBe createLoginResult()
                 }
             }

--- a/core/src/testFixtures/kotlin/com/recap/core/fixture/AuthFixtures.kt
+++ b/core/src/testFixtures/kotlin/com/recap/core/fixture/AuthFixtures.kt
@@ -1,13 +1,27 @@
 package com.recap.core.fixture
 
 import com.recap.core.domain.auth.dto.command.LoginCommand
+import com.recap.core.domain.auth.dto.command.RefreshCommand
 import com.recap.core.domain.auth.dto.response.GetOAuthUserResponse
 import com.recap.core.domain.auth.dto.result.LoginResult
+import com.recap.core.domain.auth.dto.result.RefreshResult
+import com.recap.core.domain.auth.entity.RefreshToken
 import com.recap.core.domain.user.entity.Provider
 import java.time.Duration
 
 const val TOKEN = "asddaadaddadsdasdasadsads"
 val EXPIRATION = Duration.ofHours(1)!!
+
+fun createRefreshToken(
+    userId: Long = ID,
+    content: String = TOKEN,
+    expiration: Duration = EXPIRATION
+): RefreshToken =
+    RefreshToken(
+        userId = userId,
+        content = content,
+        expiration = expiration
+    )
 
 fun createGetOAuthUserResponse(
     id: String = SOCIAL_ID,
@@ -27,11 +41,22 @@ fun createLoginCommand(
         provider = provider
     )
 
+fun createRefreshCommand(refreshToken: String = TOKEN): RefreshCommand = RefreshCommand(refreshToken = refreshToken)
+
 fun createLoginResult(
     accessToken: String = TOKEN,
     refreshToken: String = TOKEN
 ): LoginResult =
     LoginResult(
+        accessToken = accessToken,
+        refreshToken = refreshToken
+    )
+
+fun createRefreshResult(
+    accessToken: String = TOKEN,
+    refreshToken: String = TOKEN
+): RefreshResult =
+    RefreshResult(
         accessToken = accessToken,
         refreshToken = refreshToken
     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ kotlin-logging = { group = "io.github.oshai", name = "kotlin-logging-jvm", versi
 # Spring
 spring-web = { group = "org.springframework.boot", name = "spring-boot-starter-web" }
 spring-data-jpa = { group = "org.springframework.boot", name = "spring-boot-starter-data-jpa" }
+spring-data-redis = { group = "org.springframework.boot", name = "spring-boot-starter-data-redis" }
 spring-validation = { group = "org.springframework.boot", name = "spring-boot-starter-validation" }
 spring-security = { group = "org.springframework.boot", name = "spring-boot-starter-security" }
 spring-security-test = { group = "org.springframework.security", name = "spring-security-test" }


### PR DESCRIPTION
## 작업 내용

- 토큰 리프레시 기능 구현
- 테스트 코드 리팩토링

## 참고

- 논의했던 대로 리프레시 토큰에는 트랜잭션(`MULTI`, `EXEC` 등)을 사용하지 않기로 했어서, `RedisTemplate`을 쓰지 않고 그냥 RedisRepository(`CrudRepository`)를 사용했습니다.

## 관련 이슈

- close #15
