### PR TITLE
[#30] Nginx 인증서 심볼릭 링크 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,14 +133,18 @@ jobs:
       env:
         DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
         SHA: ${{ needs.build-and-push.outputs.sha }}
+        DOMAIN: dev.re-today.com
       with:
         host: ${{ secrets.SERVER_HOST }}
         username: root
         password: ${{ secrets.SERVER_PASSWORD }}
-        envs: DOCKER_USER,SHA
+        envs: DOCKER_USER,SHA,DOMAIN
         script: |
           set -e
           cd ~/retoday
+
+          export DOMAIN="${DOMAIN}"
+          envsubst '${DOMAIN}' < nginx/nginx.conf.template > nginx/nginx.conf
 
           docker pull ${DOCKER_USER}/retoday-api:${SHA}
           docker tag ${DOCKER_USER}/retoday-api:${SHA} retoday-api:latest
@@ -221,14 +225,18 @@ jobs:
       env:
         DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
         SHA: ${{ needs.build-and-push.outputs.sha }}
+        DOMAIN: api.re-today.com
       with:
         host: ${{ secrets.SERVER_HOST }}
         username: root
         password: ${{ secrets.SERVER_PASSWORD }}
-        envs: DOCKER_USER,SHA
+        envs: DOCKER_USER,SHA,DOMAIN
         script: |
           set -e
           cd ~/retoday
+
+          export DOMAIN="${DOMAIN}"
+          envsubst '${DOMAIN}' < nginx/nginx.conf.template > nginx/nginx.conf
 
           # 활성 컨테이너 확인
           if grep -q "api-blue" nginx/upstream.conf; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs:
         host: ${{ secrets.SERVER_HOST }}
         username: root
         password: ${{ secrets.SERVER_PASSWORD }}
-        source: "docker-compose.yml,nginx/nginx.conf,nginx/proxy.conf"
+        source: "docker-compose.yml,nginx/nginx.conf.template,nginx/proxy.conf"
         target: "~/retoday"
         overwrite: true
 
@@ -212,7 +212,7 @@ jobs:
         host: ${{ secrets.SERVER_HOST }}
         username: root
         password: ${{ secrets.SERVER_PASSWORD }}
-        source: "docker-compose.yml,nginx/nginx.conf,nginx/proxy.conf"
+        source: "docker-compose.yml,nginx/nginx.conf.template,nginx/proxy.conf"
         target: "~/retoday"
         overwrite: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,13 +68,11 @@ services:
   nginx:
     image: nginx:alpine
     container_name: retoday-nginx
-    environment:
-      - DOMAIN=${DOMAIN}
     ports:
     - "80:80"
     - "443:443"
     volumes:
-    - ./nginx/nginx.conf.template:/etc/nginx/templates/nginx.conf.template:ro
+    - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     - ./nginx/proxy.conf:/etc/nginx/proxy.conf:ro
     - ./nginx/upstream.conf:/etc/nginx/upstream.conf
     - /etc/letsencrypt:/etc/letsencrypt:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,14 +68,16 @@ services:
   nginx:
     image: nginx:alpine
     container_name: retoday-nginx
+    environment:
+      - DOMAIN=${DOMAIN}
     ports:
     - "80:80"
     - "443:443"
     volumes:
-    - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    - ./nginx/nginx.conf.template:/etc/nginx/templates/nginx.conf.template:ro
     - ./nginx/proxy.conf:/etc/nginx/proxy.conf:ro
     - ./nginx/upstream.conf:/etc/nginx/upstream.conf
-    - ${NGINX_CERT_DIR}:/etc/nginx/certs:ro
+    - /etc/letsencrypt:/etc/letsencrypt:ro
     - /var/www/certbot:/var/www/certbot:ro
     restart: unless-stopped
     healthcheck:

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -35,7 +35,7 @@ http {
 
     server {
         listen      80;
-        server_name api.re-today.com dev.re-today.com;
+        server_name ${DOMAIN};
         limit_conn  conn 100;
 
         location = /actuator/health {
@@ -57,7 +57,7 @@ http {
 
     server {
         listen      443 ssl;
-        server_name api.re-today.com dev.re-today.com;
+        server_name ${DOMAIN};
         http2 on;
 
         ssl_certificate           /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -56,11 +56,12 @@ http {
     }
 
     server {
-        listen      443 ssl http2;
+        listen      443 ssl;
         server_name api.re-today.com dev.re-today.com;
+        http2 on;
 
-        ssl_certificate           /etc/nginx/certs/fullchain.pem;
-        ssl_certificate_key       /etc/nginx/certs/privkey.pem;
+        ssl_certificate           /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+        ssl_certificate_key       /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
         ssl_protocols             TLSv1.2 TLSv1.3;
         ssl_ciphers               'ECDHE+AESGCM:ECDHE+CHACHA20:!aNULL:!MD5:!RC4:!3DES';
         ssl_prefer_server_ciphers on;


### PR DESCRIPTION
## 작업 내용

- Nginx 인증서 심볼릭 링크 문제 해결

## 참고

- /etc/letsencrypt 전체 마운트로 심볼릭 링크된 인증서 파일 접근 가능하도록 수정
- nginx 템플릿으로 dev/prod 인증서 경로 자동 분리
- http2 문법 수정

## 관련 이슈

- close #30 
