### PR TITLE
[#50] 소셜 프로필 연동 기능 구현

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,4 +12,3 @@ indent_size = 4
 ij_kotlin_allow_trailing_comma = false
 ij_kotlin_allow_trailing_comma_on_call_site = false
 ktlint_standard_no-wildcard-imports = disabled
-ktlint_standard_package-name = disabled

--- a/core/src/main/kotlin/com/retoday/core/domain/auth/client/GoogleClient.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/auth/client/GoogleClient.kt
@@ -17,6 +17,9 @@ class GoogleClient(
         const val USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo"
         const val ID_FIELD = "sub"
         const val EMAIL_FIELD = "email"
+        const val FIRST_NAME_FIELD = "given_name"
+        const val LAST_NAME_FIELD = "family_name"
+        const val IMAGE_URL_FIELD = "picture"
     }
 
     override fun getOAuthUserByToken(token: String): GetOAuthUserResponse =
@@ -26,11 +29,15 @@ class GoogleClient(
             .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + token)
             .retrieve()
             .onStatus({ it == HttpStatus.UNAUTHORIZED }) { _, _ -> throw InvalidOAuthTokenException() }
-            .requiredBody<Map<String, *>>()
+            .requiredBody<Map<String, String>>()
             .run {
                 GetOAuthUserResponse(
-                    id = get(ID_FIELD) as String,
-                    email = get(EMAIL_FIELD) as String
+                    id = getValue(ID_FIELD),
+                    provider = provider,
+                    email = getValue(EMAIL_FIELD),
+                    firstName = getValue(FIRST_NAME_FIELD),
+                    lastName = getValue(LAST_NAME_FIELD),
+                    imageUrl = getValue(IMAGE_URL_FIELD)
                 )
             }
 }

--- a/core/src/main/kotlin/com/retoday/core/domain/auth/dto/response/GetOAuthUserResponse.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/auth/dto/response/GetOAuthUserResponse.kt
@@ -1,6 +1,12 @@
 package com.retoday.core.domain.auth.dto.response
 
+import com.retoday.core.domain.user.entity.Provider
+
 data class GetOAuthUserResponse(
     val id: String,
-    val email: String
+    val provider: Provider,
+    val email: String,
+    val firstName: String,
+    val lastName: String,
+    val imageUrl: String
 )

--- a/core/src/main/kotlin/com/retoday/core/domain/auth/service/AuthService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/auth/service/AuthService.kt
@@ -9,9 +9,12 @@ import com.retoday.core.domain.auth.entity.RefreshToken
 import com.retoday.core.domain.auth.exception.InvalidAuthenticationException
 import com.retoday.core.domain.auth.exception.RefreshTokenNotFoundException
 import com.retoday.core.domain.auth.repository.RefreshTokenRepository
+import com.retoday.core.domain.user.entity.Profile
 import com.retoday.core.domain.user.entity.User
 import com.retoday.core.domain.user.exception.UserNotFoundException
+import com.retoday.core.domain.user.repository.ProfileRepository
 import com.retoday.core.domain.user.repository.UserRepository
+import com.retoday.core.global.extension.orElse
 import com.retoday.core.global.jwt.JwtProvider
 import com.retoday.core.global.properties.JwtProperties
 import org.springframework.data.repository.findByIdOrNull
@@ -21,37 +24,50 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class AuthService(
     private val userRepository: UserRepository,
+    private val profileRepository: ProfileRepository,
     private val refreshTokenRepository: RefreshTokenRepository,
     private val oAuthClients: List<OAuthClient>,
     private val jwtProvider: JwtProvider,
     private val jwtProperties: JwtProperties
 ) {
     @Transactional
-    fun login(command: LoginCommand): LoginResult =
-        with(command) {
-            val getOAuthUserResponse =
-                oAuthClients
-                    .first { it.provider == provider }
-                    .getOAuthUserByToken(oAuthToken)
-            val user =
-                userRepository
-                    .findBySocialIdAndProvider(getOAuthUserResponse.id, provider)
-                    ?.apply { email = getOAuthUserResponse.email }
-                    ?: User(
+    fun login(command: LoginCommand): LoginResult {
+        val getOAuthUserResponse =
+            oAuthClients
+                .first { it.provider == command.provider }
+                .getOAuthUserByToken(command.oAuthToken)
+
+        val user =
+            userRepository
+                .findBySocialIdAndProvider(getOAuthUserResponse.id, getOAuthUserResponse.provider)
+                ?.apply { synchronizeOAuthUser(getOAuthUserResponse) }
+                .orElse {
+                    User(
                         socialId = getOAuthUserResponse.id,
                         email = getOAuthUserResponse.email,
-                        provider = provider
+                        provider = getOAuthUserResponse.provider
                     )
-            val (accessToken, refreshToken) =
-                userRepository
-                    .save(user)
-                    .createTokens()
+                }.let { userRepository.save(it) }
 
-            LoginResult(
-                accessToken = accessToken,
-                refreshToken = refreshToken
-            )
-        }
+        profileRepository
+            .findByUserId(user.id!!)
+            ?.apply { synchronizeOAuthUser(getOAuthUserResponse) }
+            .orElse {
+                Profile(
+                    userId = user.id!!,
+                    firstName = getOAuthUserResponse.firstName,
+                    lastName = getOAuthUserResponse.lastName,
+                    imageUrl = getOAuthUserResponse.imageUrl
+                )
+            }.let { profileRepository.save(it) }
+
+        val (accessToken, refreshToken) = user.createTokens()
+
+        return LoginResult(
+            accessToken = accessToken,
+            refreshToken = refreshToken
+        )
+    }
 
     fun refresh(command: RefreshCommand): RefreshResult =
         with(command) {

--- a/core/src/main/kotlin/com/retoday/core/domain/auth/service/AuthService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/auth/service/AuthService.kt
@@ -69,29 +69,27 @@ class AuthService(
         )
     }
 
-    fun refresh(command: RefreshCommand): RefreshResult =
-        with(command) {
-            val userId = jwtProvider.extractUserId(refreshToken)
+    fun refresh(command: RefreshCommand): RefreshResult {
+        val userId = jwtProvider.extractUserId(command.refreshToken)
+        val refreshToken = refreshTokenRepository.findByIdOrNull(userId) ?: throw RefreshTokenNotFoundException()
 
-            refreshTokenRepository
-                .findByIdOrNull(userId)
-                ?.apply {
-                    if (content != refreshToken) {
-                        refreshTokenRepository.deleteById(userId)
+        if (refreshToken.content != command.refreshToken) {
+            refreshTokenRepository.deleteById(userId)
 
-                        throw InvalidAuthenticationException()
-                    }
-                }
-                ?: throw RefreshTokenNotFoundException()
-
-            val user = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException()
-            val (accessToken, refreshToken) = user.createTokens()
-
-            return RefreshResult(
-                accessToken = accessToken,
-                refreshToken = refreshToken
-            )
+            throw InvalidAuthenticationException()
         }
+
+        val (newAccessToken, newRefreshToken) =
+            userRepository
+                .findByIdOrNull(userId)
+                ?.createTokens()
+                ?: throw UserNotFoundException()
+
+        return RefreshResult(
+            accessToken = newAccessToken,
+            refreshToken = newRefreshToken
+        )
+    }
 
     fun logout(userId: Long) {
         refreshTokenRepository

--- a/core/src/main/kotlin/com/retoday/core/domain/user/entity/Profile.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/user/entity/Profile.kt
@@ -1,5 +1,6 @@
 package com.retoday.core.domain.user.entity
 
+import com.retoday.core.domain.auth.dto.response.GetOAuthUserResponse
 import com.retoday.core.global.entity.BaseEntity
 import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Entity
@@ -14,10 +15,16 @@ class Profile(
     @Tsid
     val id: Long? = null,
     val userId: Long,
-    val firstName: String,
-    val lastName: String,
-    val imageUrl: String,
+    var firstName: String,
+    var lastName: String,
+    var imageUrl: String,
     @Enumerated(EnumType.STRING)
     val timeZone: TimeZone = TimeZone.SEOUL,
     val recapPeriod: LocalTime? = null
-) : BaseEntity()
+) : BaseEntity() {
+    fun synchronizeOAuthUser(getOAuthUserResponse: GetOAuthUserResponse) {
+        firstName = getOAuthUserResponse.firstName
+        lastName = getOAuthUserResponse.lastName
+        imageUrl = getOAuthUserResponse.imageUrl
+    }
+}

--- a/core/src/main/kotlin/com/retoday/core/domain/user/entity/User.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/user/entity/User.kt
@@ -1,5 +1,6 @@
 package com.retoday.core.domain.user.entity
 
+import com.retoday.core.domain.auth.dto.response.GetOAuthUserResponse
 import com.retoday.core.global.entity.BaseEntity
 import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.*
@@ -18,4 +19,8 @@ class User(
     @Enumerated(EnumType.STRING)
     val roles: Set<Role> = setOf(Role.MEMBER),
     var isActive: Boolean = true
-) : BaseEntity()
+) : BaseEntity() {
+    fun synchronizeOAuthUser(getOAuthUserResponse: GetOAuthUserResponse) {
+        email = getOAuthUserResponse.email
+    }
+}

--- a/core/src/main/kotlin/com/retoday/core/domain/user/repository/ProfileRepository.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/user/repository/ProfileRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface ProfileRepository :
     JpaRepository<Profile, Long>,
-    CustomProfileRepository
+    CustomProfileRepository {
+    fun findByUserId(userId: Long): Profile?
+}

--- a/core/src/main/kotlin/com/retoday/core/global/entity/BaseEntity.kt
+++ b/core/src/main/kotlin/com/retoday/core/global/entity/BaseEntity.kt
@@ -14,7 +14,9 @@ abstract class BaseEntity {
     @CreatedDate
     @Column(nullable = false, updatable = false)
     lateinit var createdAt: Instant
+        protected set
 
     @LastModifiedDate
     var updatedAt: Instant? = null
+        protected set
 }

--- a/core/src/main/kotlin/com/retoday/core/global/extension/KotlinExtensions.kt
+++ b/core/src/main/kotlin/com/retoday/core/global/extension/KotlinExtensions.kt
@@ -1,0 +1,3 @@
+package com.retoday.core.global.extension
+
+inline fun <T> T?.orElse(block: () -> T): T = this ?: block()

--- a/core/src/test/kotlin/com/retoday/core/domain/auth/service/AuthServiceTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/auth/service/AuthServiceTest.kt
@@ -5,8 +5,10 @@ import com.retoday.core.domain.auth.exception.InvalidAuthenticationException
 import com.retoday.core.domain.auth.exception.InvalidOAuthTokenException
 import com.retoday.core.domain.auth.exception.RefreshTokenNotFoundException
 import com.retoday.core.domain.auth.repository.RefreshTokenRepository
+import com.retoday.core.domain.user.entity.Profile
 import com.retoday.core.domain.user.entity.User
 import com.retoday.core.domain.user.exception.UserNotFoundException
+import com.retoday.core.domain.user.repository.ProfileRepository
 import com.retoday.core.domain.user.repository.UserRepository
 import com.retoday.core.fixture.*
 import com.retoday.core.global.jwt.JwtProvider
@@ -19,6 +21,7 @@ import org.springframework.data.repository.findByIdOrNull
 
 class AuthServiceTest : BehaviorSpec() {
     private val userRepository = mockk<UserRepository>()
+    private val profileRepository = mockk<ProfileRepository>()
     private val refreshTokenRepository = mockk<RefreshTokenRepository>()
     private val oAuthClient = mockk<OAuthClient>()
     private val jwtProvider =
@@ -36,6 +39,7 @@ class AuthServiceTest : BehaviorSpec() {
     private val authService =
         AuthService(
             userRepository = userRepository,
+            profileRepository = profileRepository,
             refreshTokenRepository = refreshTokenRepository,
             oAuthClients = listOf(oAuthClient),
             jwtProvider = jwtProvider,
@@ -45,40 +49,26 @@ class AuthServiceTest : BehaviorSpec() {
     init {
         Given("가입한 사용자가") {
             val command = createLoginCommand()
-            val user = createUser()
+            val user = spyk(createUser())
+            val profile = spyk(createProfile())
             val refreshToken = createRefreshToken()
-            val userSlot = slot<User>()
+            val getOAuthUserResponse = createGetOAuthUserResponse()
 
             every { userRepository.findBySocialIdAndProvider(any(), any()) } returns user
-            every { userRepository.save(capture(userSlot)) } returns user
+            every { userRepository.save(any()) } returns user
+            every { profileRepository.findByUserId(any()) } returns profile
+            every { profileRepository.save(any()) } returns profile
             every { refreshTokenRepository.save(any()) } returns refreshToken
-            every { oAuthClient.provider } returns command.provider
+            every { oAuthClient.getOAuthUserByToken(any()) } returns getOAuthUserResponse
+            every { oAuthClient.provider } returns getOAuthUserResponse.provider
 
-            And("소셜 이메일이 사용자 이메일과 같은 경우") {
-                every { oAuthClient.getOAuthUserByToken(any()) } returns createGetOAuthUserResponse()
+            When("로그인을 시도하면") {
+                val result = authService.login(command)
 
-                When("로그인을 시도하면") {
-                    val result = authService.login(command)
-
-                    Then("로그인 처리가 된다.") {
-                        result shouldBe createLoginResult()
-                    }
-                }
-            }
-
-            And("소셜 이메일이 사용자 이메일과 다른 경우") {
-                val changedEmail = "1117mg@re-today.com"
-
-                every { oAuthClient.getOAuthUserByToken(any()) } returns
-                    createGetOAuthUserResponse(email = changedEmail)
-
-                When("로그인을 시도하면") {
-                    val result = authService.login(command)
-
-                    Then("사용자 이메일이 변경되고 로그인 처리가 된다.") {
-                        userSlot.captured.email shouldBe changedEmail
-                        result shouldBe createLoginResult()
-                    }
+                Then("소셜 프로필과 사용자 정보가 동기화되고 로그인 처리가 된다.") {
+                    verify { user.synchronizeOAuthUser(any()) }
+                    verify { profile.synchronizeOAuthUser(any()) }
+                    result shouldBe createLoginResult()
                 }
             }
         }
@@ -86,13 +76,17 @@ class AuthServiceTest : BehaviorSpec() {
         Given("가입하지 않은 사용자가") {
             val command = createLoginCommand()
             val user = createUser()
+            val profile = createProfile()
             val refreshToken = createRefreshToken()
             val getOAuthUserResponse = createGetOAuthUserResponse()
             val userSlot = slot<User>()
+            val profileSlot = slot<Profile>()
 
             every { userRepository.findBySocialIdAndProvider(any(), any()) } returns null
             every { userRepository.save(capture(userSlot)) } returns user
             every { refreshTokenRepository.save(any()) } returns refreshToken
+            every { profileRepository.findByUserId(any()) } returns null
+            every { profileRepository.save(capture(profileSlot)) } returns profile
             every { oAuthClient.provider } returns command.provider
             every { oAuthClient.getOAuthUserByToken(any()) } returns getOAuthUserResponse
 
@@ -101,6 +95,7 @@ class AuthServiceTest : BehaviorSpec() {
 
                 Then("회원가입과 함께 로그인 처리가 된다.") {
                     userSlot.captured.id shouldBe null
+                    profileSlot.captured.id shouldBe null
                     result shouldBe createLoginResult()
                 }
             }

--- a/core/src/test/kotlin/com/retoday/core/domain/user/entity/ProfileTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/user/entity/ProfileTest.kt
@@ -1,0 +1,37 @@
+package com.retoday.core.domain.user.entity
+
+import com.retoday.core.fixture.createGetOAuthUserResponse
+import com.retoday.core.fixture.createProfile
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class ProfileTest : BehaviorSpec() {
+    private val profile = createProfile()
+
+    init {
+        Given("가입한 사용자가") {
+            And("소셜 프로필과 다른 사용자 정보를 가지고 있는 경우") {
+                val changedFirstName = "Yelim"
+                val changedLastName = "Lee"
+                val changedImageUrl = "https://re-today.com/changed_profile.png"
+                val getOAuthUserResponse =
+                    createGetOAuthUserResponse(
+                        firstName = changedFirstName,
+                        lastName = changedLastName,
+                        imageUrl = changedImageUrl
+                    )
+
+                When("소셜 프로필과 사용자 정보를 동기화하면") {
+                    profile.synchronizeOAuthUser(getOAuthUserResponse)
+
+                    Then("이름과 성, 프로필 이미지가 업데이트된다.") {
+                        with(profile) {
+                            firstName shouldBe changedFirstName
+                            lastName shouldBe changedLastName
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/com/retoday/core/domain/user/entity/ProfileTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/user/entity/ProfileTest.kt
@@ -6,10 +6,10 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 
 class ProfileTest : BehaviorSpec() {
-    private val profile = createProfile()
-
     init {
         Given("가입한 사용자가") {
+            val profile = createProfile()
+
             And("소셜 프로필과 다른 사용자 정보를 가지고 있는 경우") {
                 val changedFirstName = "Yelim"
                 val changedLastName = "Lee"

--- a/core/src/test/kotlin/com/retoday/core/domain/user/entity/UserTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/user/entity/UserTest.kt
@@ -1,0 +1,27 @@
+package com.retoday.core.domain.user.entity
+
+import com.retoday.core.fixture.createGetOAuthUserResponse
+import com.retoday.core.fixture.createUser
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class UserTest : BehaviorSpec() {
+    private val user = createUser()
+
+    init {
+        Given("가입한 사용자가") {
+            And("소셜 프로필과 다른 사용자 정보를 가지고 있는 경우") {
+                val changedEmail = "1117mg@re-today.com"
+                val getOAuthUserResponse = createGetOAuthUserResponse(email = changedEmail)
+
+                When("소셜 프로필 정보와 사용자 정보를 동기화하면") {
+                    user.synchronizeOAuthUser(getOAuthUserResponse)
+
+                    Then("이메일이 업데이트된다.") {
+                        user.email shouldBe changedEmail
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/com/retoday/core/domain/user/entity/UserTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/user/entity/UserTest.kt
@@ -6,10 +6,10 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 
 class UserTest : BehaviorSpec() {
-    private val user = createUser()
-
     init {
         Given("가입한 사용자가") {
+            val user = createUser()
+
             And("소셜 프로필과 다른 사용자 정보를 가지고 있는 경우") {
                 val changedEmail = "1117mg@re-today.com"
                 val getOAuthUserResponse = createGetOAuthUserResponse(email = changedEmail)

--- a/core/src/testFixtures/kotlin/com/retoday/core/fixture/AuthFixtures.kt
+++ b/core/src/testFixtures/kotlin/com/retoday/core/fixture/AuthFixtures.kt
@@ -25,11 +25,19 @@ fun createRefreshToken(
 
 fun createGetOAuthUserResponse(
     id: String = SOCIAL_ID,
-    email: String = EMAIL
+    provider: Provider = PROVIDER,
+    email: String = EMAIL,
+    firstName: String = FIRST_NAME,
+    lastName: String = LAST_NAME,
+    imageUrl: String = IMAGE_URL
 ): GetOAuthUserResponse =
     GetOAuthUserResponse(
         id = id,
-        email = email
+        provider = provider,
+        email = email,
+        firstName = firstName,
+        lastName = lastName,
+        imageUrl = imageUrl
     )
 
 fun createLoginCommand(


### PR DESCRIPTION
## 작업 내용

- 소셜 프로필 연동 기능 구현
- 로그인 기능 리팩토링

## 참고

- Elvis 연산자(`?:`)는 메서드 체이닝을 더 이어가기가 불편해서 유틸리티(`orElse()`) 하나 만들었습니다.
- 도메인 엔티티의 변경 의도가 더 명확하게 보이도록, 로그인 기능 내의 프로퍼티를 변경하는 부분은 따로 엔티티 메서드로 빼냈습니다.

## 관련 이슈

- close #50
