### PR TITLE
[#57] 스크린타임 조회 기능 구현

### DIFF
--- a/api/src/main/kotlin/com/retoday/api/domain/history/controller/HistoryController.kt
+++ b/api/src/main/kotlin/com/retoday/api/domain/history/controller/HistoryController.kt
@@ -1,23 +1,47 @@
 package com.retoday.api.domain.history.controller
 
 import com.retoday.api.domain.history.dto.request.HistoryRecordRequest
+import com.retoday.api.domain.history.dto.response.GetMyScreenTimesResponse
 import com.retoday.api.domain.history.dto.response.HistoryRecordResponse
 import com.retoday.api.global.annotation.AuthenticationId
+import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
 import com.retoday.core.domain.history.service.HistoryService
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
 
 @RestController
-@RequestMapping("/api/v1/histories")
+@RequestMapping("/api/v1")
 class HistoryController(
     private val historyService: HistoryService
 ) {
-    @PostMapping
+    @PostMapping("/histories")
     fun recordHistory(
-        @AuthenticationId userId: Long,
-        @Valid @RequestBody request: HistoryRecordRequest
+        @AuthenticationId
+        userId: Long,
+        @Valid
+        @RequestBody
+        request: HistoryRecordRequest
     ): HistoryRecordResponse =
         historyService
             .recordHistory(userId, request.toCommand())
             .let { HistoryRecordResponse.from(it) }
+
+    @GetMapping("/users/me/screen-times")
+    fun getMyScreenTimes(
+        @AuthenticationId
+        userId: Long,
+        @RequestParam
+        date: LocalDate,
+        @RequestParam
+        period: GetMyScreenTimesQuery.Period
+    ): GetMyScreenTimesResponse =
+        historyService
+            .getMyScreenTimes(
+                userId,
+                GetMyScreenTimesQuery(
+                    date = date,
+                    period = period
+                )
+            ).let { GetMyScreenTimesResponse.from(it) }
 }

--- a/api/src/main/kotlin/com/retoday/api/domain/history/dto/response/GetMyScreenTimesResponse.kt
+++ b/api/src/main/kotlin/com/retoday/api/domain/history/dto/response/GetMyScreenTimesResponse.kt
@@ -3,6 +3,7 @@ package com.retoday.api.domain.history.dto.response
 import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
 import com.retoday.core.domain.history.dto.result.GetMyScreenTimesResult
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class GetMyScreenTimesResponse(
     val period: GetMyScreenTimesQuery.Period,
@@ -12,8 +13,8 @@ data class GetMyScreenTimesResponse(
     val screenTimes: List<ScreenTimeResponse>
 ) {
     data class ScreenTimeResponse(
-        val startedAt: LocalDate,
-        val endedAt: LocalDate,
+        val startedAt: LocalDateTime,
+        val endedAt: LocalDateTime,
         val stayDuration: Long
     )
 

--- a/api/src/main/kotlin/com/retoday/api/domain/history/dto/response/GetMyScreenTimesResponse.kt
+++ b/api/src/main/kotlin/com/retoday/api/domain/history/dto/response/GetMyScreenTimesResponse.kt
@@ -1,0 +1,39 @@
+package com.retoday.api.domain.history.dto.response
+
+import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
+import com.retoday.core.domain.history.dto.result.GetMyScreenTimesResult
+import java.time.LocalDate
+
+data class GetMyScreenTimesResponse(
+    val period: GetMyScreenTimesQuery.Period,
+    val startedAt: LocalDate,
+    val endedAt: LocalDate,
+    val totalStayDuration: Long,
+    val screenTimes: List<ScreenTimeResponse>
+) {
+    data class ScreenTimeResponse(
+        val startedAt: LocalDate,
+        val endedAt: LocalDate,
+        val stayDuration: Long
+    )
+
+    companion object {
+        fun from(result: GetMyScreenTimesResult): GetMyScreenTimesResponse =
+            with(result) {
+                GetMyScreenTimesResponse(
+                    period = period,
+                    startedAt = startedAt,
+                    endedAt = endedAt,
+                    totalStayDuration = totalStayDuration,
+                    screenTimes =
+                        screenTimes.map {
+                            ScreenTimeResponse(
+                                startedAt = it.startedAt,
+                                endedAt = it.endedAt,
+                                stayDuration = it.stayDuration
+                            )
+                        }
+                )
+            }
+    }
+}

--- a/api/src/test/kotlin/com/retoday/api/domain/history/HistoryControllerTest.kt
+++ b/api/src/test/kotlin/com/retoday/api/domain/history/HistoryControllerTest.kt
@@ -3,21 +3,24 @@ package com.retoday.api.domain.history
 import com.ninjasquad.springmockk.MockkBean
 import com.retoday.api.common.ControllerTest
 import com.retoday.api.domain.history.controller.HistoryController
+import com.retoday.api.domain.history.dto.response.GetMyScreenTimesResponse
 import com.retoday.api.domain.history.dto.response.HistoryRecordResponse
 import com.retoday.api.extension.*
 import com.retoday.api.fixture.createHistoryRecordRequest
-import com.retoday.api.snippet.*
+import com.retoday.api.snippet.errorResponseFields
+import com.retoday.api.snippet.getMyScreenTimesResponseFields
+import com.retoday.api.snippet.historyRecordRequestFields
+import com.retoday.api.snippet.historyRecordResponseFields
 import com.retoday.core.domain.history.dto.command.HistoryRecordCommand
-import com.retoday.core.domain.history.exception.DuplicateHistoryException
-import com.retoday.core.domain.history.exception.InvalidTimeRangeException
-import com.retoday.core.domain.history.exception.InvalidUrlException
-import com.retoday.core.domain.history.exception.RateLimitExceededException
-import com.retoday.core.domain.history.exception.WebsiteExcludedByUserException
+import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
+import com.retoday.core.domain.history.exception.*
 import com.retoday.core.domain.history.service.HistoryService
+import com.retoday.core.fixture.createGetMyScreenTimesResult
 import com.retoday.core.fixture.createHistoryRecordResult
 import io.mockk.every
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import java.time.Instant
+import java.time.LocalDate
 
 @WebMvcTest(HistoryController::class)
 class HistoryControllerTest : ControllerTest() {
@@ -132,6 +135,34 @@ class HistoryControllerTest : ControllerTest() {
                         .expectError()
                         .document("방문 기록 저장 실패 - 유효하지 않은 시간 범위(400)") {
                             responseBody(errorResponseFields)
+                        }
+                }
+            }
+        }
+
+        describe("getMyScreenTimes()은") {
+            val date = LocalDate.parse("2026-02-13")
+            val request =
+                webClient
+                    .get()
+                    .uri("/users/me/screen-times?date=$date&period=${GetMyScreenTimesQuery.Period.DAILY}")
+                    .withAuthentication()
+
+            context("유효한 요청이 주어진 경우") {
+                val result = createGetMyScreenTimesResult(date = date)
+                every { historyService.getMyScreenTimes(any(), any()) } returns result
+
+                it("상태 코드 200과 GetMyScreenTimesResponse를 반환한다.") {
+                    request
+                        .exchange()
+                        .expectStatus(200)
+                        .expectBody(GetMyScreenTimesResponse.from(result))
+                        .document("내 스크린타임 조회 성공(200)") {
+                            queryParams(
+                                "date" desc "조회 기준 일자(yyyy-MM-dd)",
+                                "period" desc "조회 기간 타입(DAILY, WEEKLY)"
+                            )
+                            responseBody(getMyScreenTimesResponseFields)
                         }
                 }
             }

--- a/api/src/testFixtures/kotlin/com/retoday/api/snippet/HistorySnippets.kt
+++ b/api/src/testFixtures/kotlin/com/retoday/api/snippet/HistorySnippets.kt
@@ -2,9 +2,11 @@ package com.retoday.api.snippet
 
 import com.retoday.api.domain.history.dto.request.HistoryRecordRequest
 import com.retoday.api.domain.history.dto.request.PageMetadata
+import com.retoday.api.domain.history.dto.response.GetMyScreenTimesResponse
 import com.retoday.api.domain.history.dto.response.HistoryRecordResponse
 import com.retoday.api.extension.desc
 import com.retoday.api.extension.fieldsOf
+import com.retoday.api.extension.listFieldsOf
 import com.retoday.api.extension.objectFieldsOf
 
 val historyRecordRequestFields =
@@ -31,3 +33,17 @@ val historyRecordResponseFields =
         HistoryRecordResponse::stayDuration desc "체류 시간 (초)",
         HistoryRecordResponse::recordedAt desc "기록 생성 시각"
     )
+
+val getMyScreenTimesResponseFields =
+    fieldsOf(
+        GetMyScreenTimesResponse::period desc "조회 기간 타입",
+        GetMyScreenTimesResponse::startedAt desc "조회 기간 시작일",
+        GetMyScreenTimesResponse::endedAt desc "조회 기간 종료일",
+        GetMyScreenTimesResponse::totalStayDuration desc "총 체류 시간(초)"
+    ) +
+        listFieldsOf(
+            GetMyScreenTimesResponse::screenTimes desc "구간별 체류 시간 목록",
+            GetMyScreenTimesResponse.ScreenTimeResponse::startedAt desc "구간 시작일",
+            GetMyScreenTimesResponse.ScreenTimeResponse::endedAt desc "구간 종료일",
+            GetMyScreenTimesResponse.ScreenTimeResponse::stayDuration desc "구간 체류 시간(초)"
+        )

--- a/api/src/testFixtures/kotlin/com/retoday/api/snippet/HistorySnippets.kt
+++ b/api/src/testFixtures/kotlin/com/retoday/api/snippet/HistorySnippets.kt
@@ -43,7 +43,7 @@ val getMyScreenTimesResponseFields =
     ) +
         listFieldsOf(
             GetMyScreenTimesResponse::screenTimes desc "구간별 체류 시간 목록",
-            GetMyScreenTimesResponse.ScreenTimeResponse::startedAt desc "구간 시작일",
-            GetMyScreenTimesResponse.ScreenTimeResponse::endedAt desc "구간 종료일",
+            GetMyScreenTimesResponse.ScreenTimeResponse::startedAt desc "구간 시작 일시",
+            GetMyScreenTimesResponse.ScreenTimeResponse::endedAt desc "구간 종료 일시",
             GetMyScreenTimesResponse.ScreenTimeResponse::stayDuration desc "구간 체류 시간(초)"
         )

--- a/core/src/main/kotlin/com/retoday/core/domain/history/dto/query/GetMyScreenTimesQuery.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/dto/query/GetMyScreenTimesQuery.kt
@@ -1,0 +1,29 @@
+package com.retoday.core.domain.history.dto.query
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+
+data class GetMyScreenTimesQuery(
+    val date: LocalDate,
+    val period: Period
+) {
+    enum class Period(
+        val screenTimeDuration: Duration,
+        val screenTimeUnit: Duration
+    ) {
+        DAILY(1.days, 2.hours),
+        WEEKLY(7.days, 1.days);
+
+        val screenTimeCount = (screenTimeDuration.inWholeHours / screenTimeUnit.inWholeHours).toInt()
+
+        fun getStartedAt(date: LocalDate): LocalDate =
+            when (this) {
+                DAILY -> date
+                WEEKLY -> date.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
+            }
+    }
+}

--- a/core/src/main/kotlin/com/retoday/core/domain/history/dto/result/GetMyScreenTimesResult.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/dto/result/GetMyScreenTimesResult.kt
@@ -2,6 +2,7 @@ package com.retoday.core.domain.history.dto.result
 
 import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class GetMyScreenTimesResult(
     val period: GetMyScreenTimesQuery.Period,
@@ -11,8 +12,8 @@ data class GetMyScreenTimesResult(
     val screenTimes: List<ScreenTime>
 ) {
     data class ScreenTime(
-        val startedAt: LocalDate,
-        val endedAt: LocalDate,
+        val startedAt: LocalDateTime,
+        val endedAt: LocalDateTime,
         val stayDuration: Long
     )
 }

--- a/core/src/main/kotlin/com/retoday/core/domain/history/dto/result/GetMyScreenTimesResult.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/dto/result/GetMyScreenTimesResult.kt
@@ -1,0 +1,18 @@
+package com.retoday.core.domain.history.dto.result
+
+import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
+import java.time.LocalDate
+
+data class GetMyScreenTimesResult(
+    val period: GetMyScreenTimesQuery.Period,
+    val startedAt: LocalDate,
+    val endedAt: LocalDate,
+    val totalStayDuration: Long,
+    val screenTimes: List<ScreenTime>
+) {
+    data class ScreenTime(
+        val startedAt: LocalDate,
+        val endedAt: LocalDate,
+        val stayDuration: Long
+    )
+}

--- a/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
@@ -10,4 +10,10 @@ interface HistoryRepository : JpaRepository<History, Long> {
         pageId: Long,
         visitedAt: Instant
     ): History?
+
+    fun findAllByUserIdAndVisitedAtBeforeAndClosedAtAfter(
+        userId: Long,
+        visitedAt: Instant,
+        closedAt: Instant
+    ): List<History>
 }

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
@@ -105,7 +105,7 @@ class HistoryService(
                         periodStartedAt
                             .plus(index * period.screenTimeUnit.inWholeSeconds, ChronoUnit.SECONDS)
                             .atZone(profile.timeZone.id)
-                            .toLocalDate()
+                            .toLocalDateTime()
                     val endedAt =
                         minOf(
                             periodEndedAt,
@@ -114,7 +114,7 @@ class HistoryService(
                                 ChronoUnit.SECONDS
                             )
                         ).atZone(profile.timeZone.id)
-                            .toLocalDate()
+                            .toLocalDateTime()
 
                     GetMyScreenTimesResult.ScreenTime(
                         startedAt = startedAt,

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
@@ -1,18 +1,23 @@
 package com.retoday.core.domain.history.service
 
 import com.retoday.core.domain.history.dto.command.HistoryRecordCommand
+import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
+import com.retoday.core.domain.history.dto.result.GetMyScreenTimesResult
 import com.retoday.core.domain.history.dto.result.HistoryRecordResult
 import com.retoday.core.domain.history.entity.History
 import com.retoday.core.domain.history.exception.DuplicateHistoryException
 import com.retoday.core.domain.history.exception.InvalidTimeRangeException
 import com.retoday.core.domain.history.repository.HistoryRepository
+import com.retoday.core.domain.user.repository.ProfileRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 @Service
 class HistoryService(
     private val historyRepository: HistoryRepository,
+    private val profileRepository: ProfileRepository,
     private val websiteService: WebsiteService,
     private val pageService: PageService
 ) {
@@ -48,6 +53,91 @@ class HistoryService(
                 )
             }
     }
+
+    @Transactional(readOnly = true)
+    fun getMyScreenTimes(
+        userId: Long,
+        query: GetMyScreenTimesQuery
+    ): GetMyScreenTimesResult =
+        with(query) {
+            val profile = profileRepository.findByUserId(userId)!!
+            val periodStartedAt =
+                period
+                    .getStartedAt(date)
+                    .atStartOfDay(profile.timeZone.id)
+                    .toInstant()
+            val periodEndedAt = periodStartedAt.plus(period.screenTimeDuration.inWholeDays, ChronoUnit.DAYS)
+            val histories =
+                historyRepository.findAllByUserIdAndVisitedAtBeforeAndClosedAtAfter(
+                    userId = userId,
+                    visitedAt = periodEndedAt,
+                    closedAt = periodStartedAt
+                )
+            val stayDurations = MutableList(period.screenTimeCount) { 0L }
+            var totalStayDuration = 0L
+
+            histories.forEach {
+                var startedAt = it.visitedAt.coerceIn(periodStartedAt, periodEndedAt)
+                val endedAt = it.closedAt.coerceIn(periodStartedAt, periodEndedAt)
+
+                while (startedAt < endedAt) {
+                    val offsetSecond = startedAt.epochSecond - periodStartedAt.epochSecond
+                    val screenTimeIndex = (offsetSecond / period.screenTimeUnit.inWholeSeconds).toInt()
+                    val segmentEnd =
+                        minOf(
+                            endedAt,
+                            periodStartedAt.plus(
+                                (screenTimeIndex + 1) * period.screenTimeUnit.inWholeSeconds,
+                                ChronoUnit.SECONDS
+                            )
+                        )
+                    val stayDuration = segmentEnd.epochSecond - startedAt.epochSecond
+
+                    stayDurations[screenTimeIndex] += stayDuration
+                    totalStayDuration += stayDuration
+                    startedAt = segmentEnd
+                }
+            }
+
+            val screenTimes =
+                stayDurations.mapIndexed { index, stayDuration ->
+                    val startedAt =
+                        periodStartedAt
+                            .plus(index * period.screenTimeUnit.inWholeSeconds, ChronoUnit.SECONDS)
+                            .atZone(profile.timeZone.id)
+                            .toLocalDate()
+                    val endedAt =
+                        minOf(
+                            periodEndedAt,
+                            periodStartedAt.plus(
+                                (index + 1) * period.screenTimeUnit.inWholeSeconds,
+                                ChronoUnit.SECONDS
+                            )
+                        ).atZone(profile.timeZone.id)
+                            .toLocalDate()
+
+                    GetMyScreenTimesResult.ScreenTime(
+                        startedAt = startedAt,
+                        endedAt = endedAt,
+                        stayDuration = stayDuration
+                    )
+                }
+
+            GetMyScreenTimesResult(
+                period = period,
+                startedAt =
+                    periodStartedAt
+                        .atZone(profile.timeZone.id)
+                        .toLocalDate(),
+                endedAt =
+                    periodEndedAt
+                        .minus(1, ChronoUnit.DAYS)
+                        .atZone(profile.timeZone.id)
+                        .toLocalDate(),
+                totalStayDuration = totalStayDuration,
+                screenTimes = screenTimes
+            )
+        }
 
     private fun checkDuplicateHistory(
         userId: Long,

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
@@ -61,28 +61,45 @@ class HistoryService(
     ): GetMyScreenTimesResult =
         with(query) {
             val profile = profileRepository.findByUserId(userId)!!
+
+            // period에 맞춰 집계 시작 시각을 계산
             val periodStartedAt =
                 period
                     .getStartedAt(date)
                     .atStartOfDay(profile.timeZone.id)
                     .toInstant()
+
+            // 집계 종료 시각은 시작 시각 + period 길이(1일/7일)로 계산
+            // 이하 집계는 [periodStartedAt, periodEndedAt) 구간 내에서 처리
             val periodEndedAt = periodStartedAt.plus(period.screenTimeDuration.inWholeDays, ChronoUnit.DAYS)
+
+            // 집계 구간과 겹치는 History([visitedAt, closedAt)와 집계 구간이 교집합을 가지는 데이터)들을 조회
             val histories =
                 historyRepository.findAllByUserIdAndVisitedAtBeforeAndClosedAtAfter(
                     userId = userId,
                     visitedAt = periodEndedAt,
                     closedAt = periodStartedAt
                 )
+
+            // 집계 구간을 period.screenTimeUnit 단위의 스크린타임들로 분할
+            // ex. DAILY: 2시간 단위 12개, WEEKLY: 하루 단위 7개.
             val stayDurations = MutableList(period.screenTimeCount) { 0L }
             var totalStayDuration = 0L
 
             histories.forEach {
+                // 개별 History가 집계 구간 밖으로 벗어날 수 있으므로 전처리
                 var startedAt = it.visitedAt.coerceIn(periodStartedAt, periodEndedAt)
                 val endedAt = it.closedAt.coerceIn(periodStartedAt, periodEndedAt)
 
+                // 하나의 History가 여러 스크린타임에 포함될 수 있으므로, period.screenTimeUnit 경계마다 분할하여 각 스크린타임에 체류시간을 배분
                 while (startedAt < endedAt) {
+                    // startedAt이 집계 시작으로부터 몇 초 떨어져 있는지 오프셋 계산
                     val offsetSecond = startedAt.epochSecond - periodStartedAt.epochSecond
+
+                    // 오프셋 기반으로 어떤 스크린타임에 포함될지 인덱스 계산
                     val screenTimeIndex = (offsetSecond / period.screenTimeUnit.inWholeSeconds).toInt()
+
+                    // 현재 스크린타임의 끝과 History 종료 시각 중 더 이른 시각까지를 이번 분할 구간으로 계산
                     val segmentEnd =
                         minOf(
                             endedAt,
@@ -91,6 +108,8 @@ class HistoryService(
                                 ChronoUnit.SECONDS
                             )
                         )
+
+                    // 현재 스크린타임에 포함될 체류시간 계산
                     val stayDuration = segmentEnd.epochSecond - startedAt.epochSecond
 
                     stayDurations[screenTimeIndex] += stayDuration

--- a/core/src/test/kotlin/com/retoday/core/domain/history/service/HistoryServiceTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/history/service/HistoryServiceTest.kt
@@ -1,9 +1,11 @@
 package com.retoday.core.domain.history.service
 
+import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
 import com.retoday.core.domain.history.exception.DuplicateHistoryException
 import com.retoday.core.domain.history.exception.InvalidTimeRangeException
 import com.retoday.core.domain.history.exception.InvalidUrlException
 import com.retoday.core.domain.history.repository.HistoryRepository
+import com.retoday.core.domain.user.repository.ProfileRepository
 import com.retoday.core.fixture.*
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -12,17 +14,20 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.time.Instant
+import java.time.LocalDate
 
 class HistoryServiceTest :
     BehaviorSpec({
         val historyRepository = mockk<HistoryRepository>()
         val websiteService = mockk<WebsiteService>()
         val pageService = mockk<PageService>()
+        val profileRepository = mockk<ProfileRepository>()
         val historyService =
             HistoryService(
-                historyRepository,
-                websiteService,
-                pageService
+                historyRepository = historyRepository,
+                websiteService = websiteService,
+                pageService = pageService,
+                profileRepository = profileRepository
             )
 
         val userId = ID
@@ -122,6 +127,129 @@ class HistoryServiceTest :
                     result.historyId shouldBe history.id
 
                     verify(exactly = 1) { historyRepository.save(any()) }
+                }
+            }
+        }
+
+        Given("일간 스크린타임 집계가 필요할 때") {
+            val targetDate = LocalDate.parse("2026-02-13")
+            val query =
+                GetMyScreenTimesQuery(
+                    date = targetDate,
+                    period = GetMyScreenTimesQuery.Period.DAILY
+                )
+            val profile = createProfile()
+            val dayStartUtc = Instant.parse("2026-02-12T15:00:00Z")
+            val dayEndUtc = Instant.parse("2026-02-13T15:00:00Z")
+            every { profileRepository.findByUserId(userId) } returns profile
+            every {
+                historyRepository.findAllByUserIdAndVisitedAtBeforeAndClosedAtAfter(
+                    userId = userId,
+                    visitedAt = dayEndUtc,
+                    closedAt = dayStartUtc
+                )
+            } returns
+                listOf(
+                    createHistory(
+                        id = 1L,
+                        websiteId = 101L,
+                        visitedAt = Instant.parse("2026-02-12T15:30:00Z"),
+                        closedAt = Instant.parse("2026-02-12T17:00:00Z"),
+                        stayDuration = 5_400
+                    ),
+                    createHistory(
+                        id = 2L,
+                        websiteId = 102L,
+                        visitedAt = Instant.parse("2026-02-12T17:30:00Z"),
+                        closedAt = Instant.parse("2026-02-12T18:30:00Z"),
+                        stayDuration = 3_600
+                    ),
+                    createHistory(
+                        id = 3L,
+                        websiteId = 103L,
+                        visitedAt = Instant.parse("2026-02-13T01:00:00Z"),
+                        closedAt = Instant.parse("2026-02-13T02:30:00Z"),
+                        stayDuration = 5_400
+                    ),
+                    createHistory(
+                        id = 4L,
+                        websiteId = 103L,
+                        visitedAt = Instant.parse("2026-02-13T02:50:00Z"),
+                        closedAt = Instant.parse("2026-02-13T03:10:00Z"),
+                        stayDuration = 1_200
+                    )
+                )
+
+            When("사용자가 본인 일간 스크린타임을 조회하면") {
+                val result = historyService.getMyScreenTimes(userId, query)
+
+                Then("2시간 단위 버킷과 총 체류 시간이 정확하게 계산된다.") {
+                    result shouldBe createGetMyScreenTimesResult(date = targetDate)
+                    verify(exactly = 1) {
+                        historyRepository.findAllByUserIdAndVisitedAtBeforeAndClosedAtAfter(
+                            userId = userId,
+                            visitedAt = dayEndUtc,
+                            closedAt = dayStartUtc
+                        )
+                    }
+                }
+            }
+        }
+
+        Given("주간 스크린타임 집계가 필요할 때") {
+            val targetDate = LocalDate.parse("2026-02-13")
+            val query =
+                GetMyScreenTimesQuery(
+                    date = targetDate,
+                    period = GetMyScreenTimesQuery.Period.WEEKLY
+                )
+            val profile = createProfile()
+            val weekStartUtc = Instant.parse("2026-02-07T15:00:00Z")
+            val weekEndUtc = Instant.parse("2026-02-14T15:00:00Z")
+            every { profileRepository.findByUserId(userId) } returns profile
+            every {
+                historyRepository.findAllByUserIdAndVisitedAtBeforeAndClosedAtAfter(
+                    userId = userId,
+                    visitedAt = weekEndUtc,
+                    closedAt = weekStartUtc
+                )
+            } returns
+                listOf(
+                    createHistory(
+                        id = 11L,
+                        websiteId = 201L,
+                        visitedAt = Instant.parse("2026-02-07T15:30:00Z"),
+                        closedAt = Instant.parse("2026-02-07T16:30:00Z"),
+                        stayDuration = 3_600
+                    ),
+                    createHistory(
+                        id = 12L,
+                        websiteId = 202L,
+                        visitedAt = Instant.parse("2026-02-10T14:00:00Z"),
+                        closedAt = Instant.parse("2026-02-10T16:00:00Z"),
+                        stayDuration = 7_200
+                    ),
+                    createHistory(
+                        id = 13L,
+                        websiteId = 203L,
+                        visitedAt = Instant.parse("2026-02-13T01:00:00Z"),
+                        closedAt = Instant.parse("2026-02-13T03:30:00Z"),
+                        stayDuration = 9_000
+                    )
+                )
+
+            When("사용자가 본인 주간 스크린타임을 조회하면") {
+                val result = historyService.getMyScreenTimes(userId, query)
+
+                Then("요일 단위 버킷과 총 체류 시간이 정확하게 계산된다.") {
+                    result shouldBe createGetMyWeeklyScreenTimesResult()
+                    verify(exactly = 1) {
+                        historyRepository.findAllByUserIdAndVisitedAtBeforeAndClosedAtAfter(
+                            userId = userId,
+                            visitedAt = weekEndUtc,
+                            closedAt = weekStartUtc
+                        )
+                    }
                 }
             }
         }

--- a/core/src/test/kotlin/com/retoday/core/domain/user/service/UserServiceTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/user/service/UserServiceTest.kt
@@ -2,10 +2,7 @@ package com.retoday.core.domain.user.service
 
 import com.retoday.core.domain.history.repository.WebsiteRepository
 import com.retoday.core.domain.user.repository.ProfileRepository
-import com.retoday.core.fixture.ID
-import com.retoday.core.fixture.USER_EX_DOMAIN
-import com.retoday.core.fixture.createGetMyProfileResult
-import com.retoday.core.fixture.createProfileWithEmail
+import com.retoday.core.fixture.*
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.equals.shouldBeEqual
 import io.mockk.every

--- a/core/src/testFixtures/kotlin/com/retoday/core/fixture/HistoryFixtures.kt
+++ b/core/src/testFixtures/kotlin/com/retoday/core/fixture/HistoryFixtures.kt
@@ -44,68 +44,14 @@ fun createGetMyScreenTimesResult(date: LocalDate = LocalDate.parse("2026-02-13")
         endedAt = date,
         totalStayDuration = 15_600L,
         screenTimes =
-            listOf(
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 5_400L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 3_600L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 0L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 0L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 0L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 6_000L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 600L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 0L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 0L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 0L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date,
-                    stayDuration = 0L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = date,
-                    endedAt = date.plusDays(1),
-                    stayDuration = 0L
-                )
-            )
+            listOf(5_400L, 3_600L, 0L, 0L, 0L, 6_000L, 600L, 0L, 0L, 0L, 0L, 0L)
+                .mapIndexed { index, stayDuration ->
+                    GetMyScreenTimesResult.ScreenTime(
+                        startedAt = date.atStartOfDay().plusHours(index * 2L),
+                        endedAt = date.atStartOfDay().plusHours((index + 1) * 2L),
+                        stayDuration = stayDuration
+                    )
+                }
     )
 
 fun createGetMyWeeklyScreenTimesResult(): GetMyScreenTimesResult =
@@ -115,43 +61,14 @@ fun createGetMyWeeklyScreenTimesResult(): GetMyScreenTimesResult =
         endedAt = LocalDate.parse("2026-02-14"),
         totalStayDuration = 19_800L,
         screenTimes =
-            listOf(
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = LocalDate.parse("2026-02-08"),
-                    endedAt = LocalDate.parse("2026-02-09"),
-                    stayDuration = 3_600L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = LocalDate.parse("2026-02-09"),
-                    endedAt = LocalDate.parse("2026-02-10"),
-                    stayDuration = 0L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = LocalDate.parse("2026-02-10"),
-                    endedAt = LocalDate.parse("2026-02-11"),
-                    stayDuration = 3_600L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = LocalDate.parse("2026-02-11"),
-                    endedAt = LocalDate.parse("2026-02-12"),
-                    stayDuration = 3_600L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = LocalDate.parse("2026-02-12"),
-                    endedAt = LocalDate.parse("2026-02-13"),
-                    stayDuration = 0L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = LocalDate.parse("2026-02-13"),
-                    endedAt = LocalDate.parse("2026-02-14"),
-                    stayDuration = 9_000L
-                ),
-                GetMyScreenTimesResult.ScreenTime(
-                    startedAt = LocalDate.parse("2026-02-14"),
-                    endedAt = LocalDate.parse("2026-02-15"),
-                    stayDuration = 0L
-                )
-            )
+            listOf(3_600L, 0L, 3_600L, 3_600L, 0L, 9_000L, 0L)
+                .mapIndexed { index, stayDuration ->
+                    GetMyScreenTimesResult.ScreenTime(
+                        startedAt = LocalDate.parse("2026-02-08").atStartOfDay().plusDays(index.toLong()),
+                        endedAt = LocalDate.parse("2026-02-08").atStartOfDay().plusDays((index + 1).toLong()),
+                        stayDuration = stayDuration
+                    )
+                }
     )
 
 fun createWebsite(

--- a/core/src/testFixtures/kotlin/com/retoday/core/fixture/HistoryFixtures.kt
+++ b/core/src/testFixtures/kotlin/com/retoday/core/fixture/HistoryFixtures.kt
@@ -1,6 +1,8 @@
 package com.retoday.core.fixture
 
 import com.retoday.core.domain.history.dto.command.HistoryRecordCommand
+import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
+import com.retoday.core.domain.history.dto.result.GetMyScreenTimesResult
 import com.retoday.core.domain.history.dto.result.HistoryRecordResult
 import com.retoday.core.domain.history.entity.History
 import com.retoday.core.domain.history.entity.Page
@@ -33,6 +35,123 @@ fun createHistoryRecordResult(
         websiteId = websiteId,
         stayDuration = stayDuration,
         recordedAt = recordedAt
+    )
+
+fun createGetMyScreenTimesResult(date: LocalDate = LocalDate.parse("2026-02-13")): GetMyScreenTimesResult =
+    GetMyScreenTimesResult(
+        period = GetMyScreenTimesQuery.Period.DAILY,
+        startedAt = date,
+        endedAt = date,
+        totalStayDuration = 15_600L,
+        screenTimes =
+            listOf(
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 5_400L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 3_600L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 0L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 0L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 0L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 6_000L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 600L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 0L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 0L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 0L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date,
+                    stayDuration = 0L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = date,
+                    endedAt = date.plusDays(1),
+                    stayDuration = 0L
+                )
+            )
+    )
+
+fun createGetMyWeeklyScreenTimesResult(): GetMyScreenTimesResult =
+    GetMyScreenTimesResult(
+        period = GetMyScreenTimesQuery.Period.WEEKLY,
+        startedAt = LocalDate.parse("2026-02-08"),
+        endedAt = LocalDate.parse("2026-02-14"),
+        totalStayDuration = 19_800L,
+        screenTimes =
+            listOf(
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = LocalDate.parse("2026-02-08"),
+                    endedAt = LocalDate.parse("2026-02-09"),
+                    stayDuration = 3_600L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = LocalDate.parse("2026-02-09"),
+                    endedAt = LocalDate.parse("2026-02-10"),
+                    stayDuration = 0L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = LocalDate.parse("2026-02-10"),
+                    endedAt = LocalDate.parse("2026-02-11"),
+                    stayDuration = 3_600L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = LocalDate.parse("2026-02-11"),
+                    endedAt = LocalDate.parse("2026-02-12"),
+                    stayDuration = 3_600L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = LocalDate.parse("2026-02-12"),
+                    endedAt = LocalDate.parse("2026-02-13"),
+                    stayDuration = 0L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = LocalDate.parse("2026-02-13"),
+                    endedAt = LocalDate.parse("2026-02-14"),
+                    stayDuration = 9_000L
+                ),
+                GetMyScreenTimesResult.ScreenTime(
+                    startedAt = LocalDate.parse("2026-02-14"),
+                    endedAt = LocalDate.parse("2026-02-15"),
+                    stayDuration = 0L
+                )
+            )
     )
 
 fun createWebsite(


### PR DESCRIPTION
## 작업 내용

- 스크린타임 조회 기능 구현

## 참고

- 쿼리만으로 스크린타임을 계산하는 방식이 성능상 더 유리할 수 있긴 합니다.
  - 그러나 `WITH RECURSIVE` 등을 사용해야 하므로 복잡하고 관리하기 힘든 네이티브 쿼리를 사용해야 합니다.
  - 또한 현재 비즈니스 로직의 시간 복잡도는 O(N) 수준으로 충분히 감당 가능한 범위라고 판단하여, 애플리케이션 단에서 해당 기간의 기록을 모두 조회해 스크린타임을 계산하도록 구현하였습니다.
  - 향후 기록 수 증가로 병목이 발생하는 사례가 빈번히 관찰되거나, 월간 스크린타임 조회 기능이 추가될 경우에는 쿼리 기반 구조로 전환을 검토할 예정입니다.
- 생각보다 구현 난이도가 좀 있어서 코테 푸는 것 같았습니다;;

## 관련 이슈

- close #57
