### PR TITLE
[#59] 카테고리 분석 조회 기능 구현

### DIFF
--- a/api/src/main/kotlin/com/retoday/api/domain/history/controller/HistoryController.kt
+++ b/api/src/main/kotlin/com/retoday/api/domain/history/controller/HistoryController.kt
@@ -1,9 +1,11 @@
 package com.retoday.api.domain.history.controller
 
 import com.retoday.api.domain.history.dto.request.HistoryRecordRequest
+import com.retoday.api.domain.history.dto.response.GetMyCategoryAnalysesResponse
 import com.retoday.api.domain.history.dto.response.GetMyScreenTimesResponse
 import com.retoday.api.domain.history.dto.response.HistoryRecordResponse
 import com.retoday.api.global.annotation.AuthenticationId
+import com.retoday.core.domain.history.dto.query.GetMyCategoryAnalysisQuery
 import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
 import com.retoday.core.domain.history.service.HistoryService
 import jakarta.validation.Valid
@@ -44,4 +46,15 @@ class HistoryController(
                     period = period
                 )
             ).let { GetMyScreenTimesResponse.from(it) }
+
+    @GetMapping("/users/me/category-analyses")
+    fun getMyCategoryAnalyses(
+        @AuthenticationId
+        userId: Long,
+        @RequestParam
+        date: LocalDate
+    ): GetMyCategoryAnalysesResponse =
+        historyService
+            .getMyCategoryAnalyses(userId, GetMyCategoryAnalysisQuery(date = date))
+            .let { GetMyCategoryAnalysesResponse.from(it) }
 }

--- a/api/src/main/kotlin/com/retoday/api/domain/history/dto/response/GetMyCategoryAnalysesResponse.kt
+++ b/api/src/main/kotlin/com/retoday/api/domain/history/dto/response/GetMyCategoryAnalysesResponse.kt
@@ -1,0 +1,19 @@
+package com.retoday.api.domain.history.dto.response
+
+import com.retoday.core.domain.history.dto.result.GetMyCategoryAnalysesResult
+import java.time.LocalDate
+
+data class GetMyCategoryAnalysesResponse(
+    val date: LocalDate,
+    val categoryAnalyses: List<GetMyCategoryAnalysesResult.CategoryAnalysis>
+) {
+    companion object {
+        fun from(result: GetMyCategoryAnalysesResult): GetMyCategoryAnalysesResponse =
+            with(result) {
+                GetMyCategoryAnalysesResponse(
+                    date = date,
+                    categoryAnalyses = categoryAnalyses
+                )
+            }
+    }
+}

--- a/api/src/test/kotlin/com/retoday/api/domain/history/HistoryControllerTest.kt
+++ b/api/src/test/kotlin/com/retoday/api/domain/history/HistoryControllerTest.kt
@@ -3,18 +3,18 @@ package com.retoday.api.domain.history
 import com.ninjasquad.springmockk.MockkBean
 import com.retoday.api.common.ControllerTest
 import com.retoday.api.domain.history.controller.HistoryController
+import com.retoday.api.domain.history.dto.response.GetMyCategoryAnalysesResponse
 import com.retoday.api.domain.history.dto.response.GetMyScreenTimesResponse
 import com.retoday.api.domain.history.dto.response.HistoryRecordResponse
 import com.retoday.api.extension.*
+import com.retoday.api.fixture.HISTORY_DOMAIN
+import com.retoday.api.fixture.HISTORY_URL
 import com.retoday.api.fixture.createHistoryRecordRequest
-import com.retoday.api.snippet.errorResponseFields
-import com.retoday.api.snippet.getMyScreenTimesResponseFields
-import com.retoday.api.snippet.historyRecordRequestFields
-import com.retoday.api.snippet.historyRecordResponseFields
-import com.retoday.core.domain.history.dto.command.HistoryRecordCommand
+import com.retoday.api.snippet.*
 import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
 import com.retoday.core.domain.history.exception.*
 import com.retoday.core.domain.history.service.HistoryService
+import com.retoday.core.fixture.createGetMyCategoryAnalysisResult
 import com.retoday.core.fixture.createGetMyScreenTimesResult
 import com.retoday.core.fixture.createHistoryRecordResult
 import io.mockk.every
@@ -29,7 +29,11 @@ class HistoryControllerTest : ControllerTest() {
 
     init {
         describe("recordHistory()는") {
-            val baseRequest = { webClient.post().uri("/histories") }
+            val baseRequest = {
+                webClient
+                    .post()
+                    .uri("/histories")
+            }
             val authenticatedRequest = { request: Any ->
                 baseRequest()
                     .bodyValue(request)
@@ -40,9 +44,7 @@ class HistoryControllerTest : ControllerTest() {
             context("유효한 요청이 주어진 경우") {
                 val result = createHistoryRecordResult()
 
-                every {
-                    historyService.recordHistory(any<Long>(), any<HistoryRecordCommand>())
-                } returns result
+                every { historyService.recordHistory(any(), any()) } returns result
 
                 it("상태 코드 200과 HistoryRecordResponse를 반환한다.") {
                     authenticatedRequest(createHistoryRecordRequest())
@@ -57,8 +59,8 @@ class HistoryControllerTest : ControllerTest() {
 
             context("사용자가 제외한 도메인인 경우") {
                 every {
-                    historyService.recordHistory(any<Long>(), any<HistoryRecordCommand>())
-                } throws WebsiteExcludedByUserException("github.com")
+                    historyService.recordHistory(any(), any())
+                } throws WebsiteExcludedByUserException(HISTORY_DOMAIN)
 
                 it("상태 코드 204와 ErrorResponse를 반환한다.") {
                     authenticatedRequest(createHistoryRecordRequest())
@@ -72,7 +74,7 @@ class HistoryControllerTest : ControllerTest() {
 
             context("유효하지 않은 URL이 주어진 경우") {
                 every {
-                    historyService.recordHistory(any<Long>(), any<HistoryRecordCommand>())
+                    historyService.recordHistory(any(), any())
                 } throws InvalidUrlException("invalid-url")
 
                 it("상태 코드 400과 ErrorResponse를 반환한다.") {
@@ -88,8 +90,8 @@ class HistoryControllerTest : ControllerTest() {
 
             context("중복된 요청이 주어진 경우") {
                 every {
-                    historyService.recordHistory(any<Long>(), any<HistoryRecordCommand>())
-                } throws DuplicateHistoryException(1, "https://github.com/Nexters/retoday-server")
+                    historyService.recordHistory(any(), any())
+                } throws DuplicateHistoryException(1, HISTORY_URL)
 
                 it("상태 코드 409와 ErrorResponse를 반환한다.") {
                     authenticatedRequest(createHistoryRecordRequest())
@@ -104,7 +106,7 @@ class HistoryControllerTest : ControllerTest() {
 
             context("Rate Limit을 초과한 경우") {
                 every {
-                    historyService.recordHistory(any<Long>(), any<HistoryRecordCommand>())
+                    historyService.recordHistory(any(), any())
                 } throws RateLimitExceededException(1L, 60L)
 
                 it("상태 코드 429와 ErrorResponse를 반환한다.") {
@@ -122,7 +124,7 @@ class HistoryControllerTest : ControllerTest() {
                 val now = Instant.now()
 
                 every {
-                    historyService.recordHistory(any<Long>(), any<HistoryRecordCommand>())
+                    historyService.recordHistory(any(), any())
                 } throws InvalidTimeRangeException("closedAt은 visitedAt보다 이후여야 합니다")
 
                 it("상태 코드 400과 ErrorResponse를 반환한다.") {
@@ -158,11 +160,33 @@ class HistoryControllerTest : ControllerTest() {
                         .expectStatus(200)
                         .expectBody(GetMyScreenTimesResponse.from(result))
                         .document("내 스크린타임 조회 성공(200)") {
-                            queryParams(
-                                "date" desc "조회 기준 일자(yyyy-MM-dd)",
-                                "period" desc "조회 기간 타입(DAILY, WEEKLY)"
-                            )
+                            queryParams(getMyScreenTimesQueryFields)
                             responseBody(getMyScreenTimesResponseFields)
+                        }
+                }
+            }
+        }
+
+        describe("getMyCategoryAnalyses()은") {
+            val date = LocalDate.parse("2026-02-13")
+            val request =
+                webClient
+                    .get()
+                    .uri("/users/me/category-analyses?date=$date")
+                    .withAuthentication()
+
+            context("유효한 요청이 주어진 경우") {
+                val result = createGetMyCategoryAnalysisResult(date = date)
+                every { historyService.getMyCategoryAnalyses(any(), any()) } returns result
+
+                it("상태 코드 200과 GetMyCategoryAnalysisResponse를 반환한다.") {
+                    request
+                        .exchange()
+                        .expectStatus(200)
+                        .expectBody(GetMyCategoryAnalysesResponse.from(result))
+                        .document("내 카테고리 분석 조회 성공(200)") {
+                            queryParams(getMyCategoryAnalysisQueryFields)
+                            responseBody(getMyCategoryAnalysesResponseFields)
                         }
                 }
             }

--- a/api/src/testFixtures/kotlin/com/retoday/api/extension/RestDocsExtensions.kt
+++ b/api/src/testFixtures/kotlin/com/retoday/api/extension/RestDocsExtensions.kt
@@ -8,11 +8,25 @@ import org.springframework.restdocs.snippet.Snippet
 import org.springframework.test.web.reactive.server.WebTestClient.BodySpec
 import kotlin.reflect.KProperty
 
-private typealias Field = Pair<String, String>
+data class Field(
+    val name: String,
+    val description: String,
+    val isOptional: Boolean = false
+)
 
-infix fun String.desc(description: String): Field = this to description
+fun optional(field: Field): Field = field.copy(isOptional = true)
 
-infix fun <T> KProperty<T>.desc(description: String): Field = name to description
+infix fun String.desc(description: String): Field =
+    Field(
+        name = this,
+        description = description
+    )
+
+infix fun <T> KProperty<T>.desc(description: String): Field =
+    Field(
+        name = name,
+        description = description
+    )
 
 fun fieldsOf(vararg fields: Field): Array<Field> = fields as Array<Field>
 
@@ -21,7 +35,7 @@ fun listFieldsOf(
     vararg fields: Field
 ): Array<Field> =
     fields
-        .map { "${listField.first}[].${it.first}" desc it.second }
+        .map { "${listField.name}[].${it.name}" desc it.description }
         .plus(listField)
         .toTypedArray()
 
@@ -30,23 +44,21 @@ fun objectFieldsOf(
     vararg fields: Field
 ): Array<Field> =
     fields
-        .map { "${objectField.first}.${it.first}" desc it.second }
+        .map { "${objectField.name}.${it.name}" desc it.description }
         .plus(objectField)
         .toTypedArray()
 
 fun <T> BodySpec<T, *>.document(
     identifier: String,
-    nullableFields: Set<String> = emptySet(),
     init: (DocumentDsl<T>.() -> Unit)? = null
 ): BodySpec<T, *> =
-    DocumentDsl(identifier, this, nullableFields)
+    DocumentDsl(identifier, this)
         .apply { init?.let { it() } }
         .build()
 
 class DocumentDsl<T>(
     private val identifier: String,
-    private val contentSpec: BodySpec<T, *>,
-    private val nullableFields: Set<String>
+    private val contentSpec: BodySpec<T, *>
 ) {
     private val snippets: MutableList<Snippet> = mutableListOf()
 
@@ -54,8 +66,9 @@ class DocumentDsl<T>(
         snippets.add(
             requestFields(
                 fields.map {
-                    fieldWithPath(it.first)
-                        .description(it.second)
+                    fieldWithPath(it.name)
+                        .description(it.description)
+                        .apply { if (it.isOptional) optional() }
                 }
             )
         )
@@ -65,8 +78,9 @@ class DocumentDsl<T>(
         snippets.add(
             requestParts(
                 fields.map {
-                    partWithName(it.first)
-                        .description(it.second)
+                    partWithName(it.name)
+                        .description(it.description)
+                        .apply { if (it.isOptional) optional() }
                 }
             )
         )
@@ -76,8 +90,9 @@ class DocumentDsl<T>(
         snippets.add(
             pathParameters(
                 fields.map {
-                    parameterWithName(it.first)
-                        .description(it.second)
+                    parameterWithName(it.name)
+                        .description(it.description)
+                        .apply { if (it.isOptional) optional() }
                 }
             )
         )
@@ -87,8 +102,9 @@ class DocumentDsl<T>(
         snippets.add(
             queryParameters(
                 fields.map {
-                    parameterWithName(it.first)
-                        .description(it.second)
+                    parameterWithName(it.name)
+                        .description(it.description)
+                        .apply { if (it.isOptional) optional() }
                 }
             )
         )
@@ -98,15 +114,8 @@ class DocumentDsl<T>(
         snippets.add(
             responseFields(
                 fields.map {
-                    val descriptor =
-                        fieldWithPath(it.first)
-                            .description(it.second)
-
-                    if (nullableFields.contains(it.first)) {
-                        descriptor.optional()
-                    } else {
-                        descriptor
-                    }
+                    fieldWithPath(it.name)
+                        .description(it.description)
                 }
             )
         )

--- a/api/src/testFixtures/kotlin/com/retoday/api/extension/RestDocsExtensions.kt
+++ b/api/src/testFixtures/kotlin/com/retoday/api/extension/RestDocsExtensions.kt
@@ -14,17 +14,25 @@ infix fun String.desc(description: String): Field = this to description
 
 infix fun <T> KProperty<T>.desc(description: String): Field = name to description
 
-fun fieldsOf(vararg fields: Field): List<Field> = fields.asList()
+fun fieldsOf(vararg fields: Field): Array<Field> = fields as Array<Field>
 
 fun listFieldsOf(
     listField: Field,
     vararg fields: Field
-): List<Field> = fields.map { "${listField.first}[].${it.first}" desc it.second } + listField
+): Array<Field> =
+    fields
+        .map { "${listField.first}[].${it.first}" desc it.second }
+        .plus(listField)
+        .toTypedArray()
 
 fun objectFieldsOf(
     objectField: Field,
     vararg fields: Field
-): List<Field> = fields.map { "${objectField.first}.${it.first}" desc it.second } + objectField
+): Array<Field> =
+    fields
+        .map { "${objectField.first}.${it.first}" desc it.second }
+        .plus(objectField)
+        .toTypedArray()
 
 fun <T> BodySpec<T, *>.document(
     identifier: String,
@@ -42,7 +50,7 @@ class DocumentDsl<T>(
 ) {
     private val snippets: MutableList<Snippet> = mutableListOf()
 
-    fun requestBody(fields: List<Field>) {
+    fun requestBody(fields: Array<Field>) {
         snippets.add(
             requestFields(
                 fields.map {
@@ -53,7 +61,7 @@ class DocumentDsl<T>(
         )
     }
 
-    fun requestForm(fields: List<Field>) {
+    fun requestForm(fields: Array<Field>) {
         snippets.add(
             requestParts(
                 fields.map {
@@ -75,7 +83,7 @@ class DocumentDsl<T>(
         )
     }
 
-    fun queryParams(vararg fields: Field) {
+    fun queryParams(fields: Array<Field>) {
         snippets.add(
             queryParameters(
                 fields.map {
@@ -86,7 +94,7 @@ class DocumentDsl<T>(
         )
     }
 
-    fun responseBody(fields: List<Field>) {
+    fun responseBody(fields: Array<Field>) {
         snippets.add(
             responseFields(
                 fields.map {

--- a/api/src/testFixtures/kotlin/com/retoday/api/fixture/HistoryFixtures.kt
+++ b/api/src/testFixtures/kotlin/com/retoday/api/fixture/HistoryFixtures.kt
@@ -6,6 +6,7 @@ import java.time.Instant
 
 const val TAB_ID = 1
 const val HISTORY_URL = "https://github.com/Nexters/retoday-server"
+const val HISTORY_DOMAIN = "github.com"
 val VISITED_AT: Instant = Instant.parse("2026-02-07T07:11:47.403Z")
 val CLOSED_AT: Instant = Instant.parse("2026-02-07T07:11:50.887Z")
 const val TITLE = "GitHub"

--- a/api/src/testFixtures/kotlin/com/retoday/api/snippet/HistorySnippets.kt
+++ b/api/src/testFixtures/kotlin/com/retoday/api/snippet/HistorySnippets.kt
@@ -9,6 +9,8 @@ import com.retoday.api.extension.desc
 import com.retoday.api.extension.fieldsOf
 import com.retoday.api.extension.listFieldsOf
 import com.retoday.api.extension.objectFieldsOf
+import com.retoday.core.domain.history.dto.query.GetMyCategoryAnalysisQuery
+import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
 import com.retoday.core.domain.history.dto.result.GetMyCategoryAnalysesResult
 
 val historyRecordRequestFields =
@@ -38,8 +40,8 @@ val historyRecordResponseFields =
 
 val getMyScreenTimesQueryFields =
     fieldsOf(
-        "date" desc "조회 기준 일자(yyyy-MM-dd)",
-        "period" desc "조회 기간 타입(DAILY, WEEKLY)"
+        GetMyScreenTimesQuery::date desc "조회 기준 일자(yyyy-MM-dd)",
+        GetMyScreenTimesQuery::period desc "조회 기간 타입(DAILY, WEEKLY)"
     )
 
 val getMyScreenTimesResponseFields =
@@ -58,7 +60,7 @@ val getMyScreenTimesResponseFields =
 
 val getMyCategoryAnalysisQueryFields =
     fieldsOf(
-        "date" desc "조회 기준 일자(yyyy-MM-dd)"
+        GetMyCategoryAnalysisQuery::date desc "조회 기준 일자(yyyy-MM-dd)"
     )
 
 val getMyCategoryAnalysesResponseFields =

--- a/api/src/testFixtures/kotlin/com/retoday/api/snippet/HistorySnippets.kt
+++ b/api/src/testFixtures/kotlin/com/retoday/api/snippet/HistorySnippets.kt
@@ -2,12 +2,14 @@ package com.retoday.api.snippet
 
 import com.retoday.api.domain.history.dto.request.HistoryRecordRequest
 import com.retoday.api.domain.history.dto.request.PageMetadata
+import com.retoday.api.domain.history.dto.response.GetMyCategoryAnalysesResponse
 import com.retoday.api.domain.history.dto.response.GetMyScreenTimesResponse
 import com.retoday.api.domain.history.dto.response.HistoryRecordResponse
 import com.retoday.api.extension.desc
 import com.retoday.api.extension.fieldsOf
 import com.retoday.api.extension.listFieldsOf
 import com.retoday.api.extension.objectFieldsOf
+import com.retoday.core.domain.history.dto.result.GetMyCategoryAnalysesResult
 
 val historyRecordRequestFields =
     fieldsOf(
@@ -17,13 +19,13 @@ val historyRecordRequestFields =
         HistoryRecordRequest::closedAt desc "탭 종료/이동 시각 (ISO 8601)",
         HistoryRecordRequest::title desc "페이지 제목 (최대 500자)",
         HistoryRecordRequest::isClosed desc "탭 종료 여부 (true: 종료, false: 이동)",
-        HistoryRecordRequest::scrollDepth desc "최대 스크롤 깊이 (0-100)"
-    ) +
-        objectFieldsOf(
-            HistoryRecordRequest::metadata desc "페이지 메타데이터",
+        HistoryRecordRequest::scrollDepth desc "최대 스크롤 깊이 (0-100)",
+        *objectFieldsOf(
+            objectField = HistoryRecordRequest::metadata desc "페이지 메타데이터",
             PageMetadata::description desc "페이지 설명 (최대 5000자)",
             PageMetadata::faviconUrl desc "파비콘 URL (최대 500자)"
         )
+    )
 
 val historyRecordResponseFields =
     fieldsOf(
@@ -34,16 +36,43 @@ val historyRecordResponseFields =
         HistoryRecordResponse::recordedAt desc "기록 생성 시각"
     )
 
+val getMyScreenTimesQueryFields =
+    fieldsOf(
+        "date" desc "조회 기준 일자(yyyy-MM-dd)",
+        "period" desc "조회 기간 타입(DAILY, WEEKLY)"
+    )
+
 val getMyScreenTimesResponseFields =
     fieldsOf(
         GetMyScreenTimesResponse::period desc "조회 기간 타입",
         GetMyScreenTimesResponse::startedAt desc "조회 기간 시작일",
         GetMyScreenTimesResponse::endedAt desc "조회 기간 종료일",
-        GetMyScreenTimesResponse::totalStayDuration desc "총 체류 시간(초)"
-    ) +
-        listFieldsOf(
-            GetMyScreenTimesResponse::screenTimes desc "구간별 체류 시간 목록",
+        GetMyScreenTimesResponse::totalStayDuration desc "총 체류 시간(초)",
+        *listFieldsOf(
+            listField = GetMyScreenTimesResponse::screenTimes desc "구간별 체류 시간 목록",
             GetMyScreenTimesResponse.ScreenTimeResponse::startedAt desc "구간 시작 일시",
             GetMyScreenTimesResponse.ScreenTimeResponse::endedAt desc "구간 종료 일시",
             GetMyScreenTimesResponse.ScreenTimeResponse::stayDuration desc "구간 체류 시간(초)"
         )
+    )
+
+val getMyCategoryAnalysisQueryFields =
+    fieldsOf(
+        "date" desc "조회 기준 일자(yyyy-MM-dd)"
+    )
+
+val getMyCategoryAnalysesResponseFields =
+    fieldsOf(
+        GetMyCategoryAnalysesResponse::date desc "조회 기준 일자",
+        *listFieldsOf(
+            listField = GetMyCategoryAnalysesResponse::categoryAnalyses desc "카테고리별 분석 목록",
+            GetMyCategoryAnalysesResult.CategoryAnalysis::categoryName desc "카테고리 이름",
+            GetMyCategoryAnalysesResult.CategoryAnalysis::stayDuration desc "카테고리 총 체류 시간(초)",
+            *listFieldsOf(
+                listField = GetMyCategoryAnalysesResult.CategoryAnalysis::websiteAnalyses desc "카테고리 내 도메인 분석 목록",
+                GetMyCategoryAnalysesResult.WebsiteAnalysis::domain desc "도메인",
+                GetMyCategoryAnalysesResult.WebsiteAnalysis::faviconUrl desc "파비콘 URL",
+                GetMyCategoryAnalysesResult.WebsiteAnalysis::stayDuration desc "도메인 체류 시간(초)"
+            )
+        )
+    )

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,10 +14,10 @@ dependencies {
     implementation(libs.spring.data.redis)
     implementation(libs.spring.log4j2)
     implementation(libs.hypersistence.utils)
+    implementation(libs.google.gemini)
+    implementation(libs.jackson.kotlin)
     implementation(libs.bundles.jdsl)
     implementation(libs.bundles.jwt)
-    implementation(libs.gemini.google)
-    implementation(libs.jackson.module.kotlin)
     runtimeOnly(libs.mysql.connector)
 
     testImplementation(libs.spring.test)
@@ -26,6 +26,7 @@ dependencies {
     testFixturesImplementation(libs.jdsl.jpa)
     testFixturesImplementation(libs.bundles.test)
     testFixturesImplementation(libs.bundles.spring.test)
+    testFixturesImplementation(libs.bundles.test.containers)
 }
 
 tasks {

--- a/core/src/main/kotlin/com/retoday/core/domain/history/dto/projection/WebsiteForCategoryAnalysis.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/dto/projection/WebsiteForCategoryAnalysis.kt
@@ -1,0 +1,8 @@
+package com.retoday.core.domain.history.dto.projection
+
+interface WebsiteForCategoryAnalysis {
+    val domain: String
+    val faviconUrl: String?
+    val categoryName: String?
+    val stayDuration: Long
+}

--- a/core/src/main/kotlin/com/retoday/core/domain/history/dto/projection/WebsiteForCategoryAnalysis.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/dto/projection/WebsiteForCategoryAnalysis.kt
@@ -1,8 +1,0 @@
-package com.retoday.core.domain.history.dto.projection
-
-interface WebsiteForCategoryAnalysis {
-    val domain: String
-    val faviconUrl: String?
-    val categoryName: String?
-    val stayDuration: Long
-}

--- a/core/src/main/kotlin/com/retoday/core/domain/history/dto/projection/WebsiteStatWithCategory.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/dto/projection/WebsiteStatWithCategory.kt
@@ -1,0 +1,8 @@
+package com.retoday.core.domain.history.dto.projection
+
+data class WebsiteStatWithCategory(
+    val domain: String,
+    val faviconUrl: String?,
+    val categoryName: String?,
+    val stayDuration: Long
+)

--- a/core/src/main/kotlin/com/retoday/core/domain/history/dto/query/GetMyCategoryAnalysisQuery.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/dto/query/GetMyCategoryAnalysisQuery.kt
@@ -1,0 +1,7 @@
+package com.retoday.core.domain.history.dto.query
+
+import java.time.LocalDate
+
+data class GetMyCategoryAnalysisQuery(
+    val date: LocalDate
+)

--- a/core/src/main/kotlin/com/retoday/core/domain/history/dto/result/GetMyCategoryAnalysesResult.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/dto/result/GetMyCategoryAnalysesResult.kt
@@ -1,0 +1,21 @@
+package com.retoday.core.domain.history.dto.result
+
+import java.time.LocalDate
+
+data class GetMyCategoryAnalysesResult(
+    val date: LocalDate,
+    val totalStayDuration: Long,
+    val categoryAnalyses: List<CategoryAnalysis>
+) {
+    data class CategoryAnalysis(
+        val categoryName: String,
+        val stayDuration: Long,
+        val websiteAnalyses: List<WebsiteAnalysis>
+    )
+
+    data class WebsiteAnalysis(
+        val domain: String,
+        val faviconUrl: String?,
+        val stayDuration: Long
+    )
+}

--- a/core/src/main/kotlin/com/retoday/core/domain/history/entity/History.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/entity/History.kt
@@ -2,14 +2,17 @@ package com.retoday.core.domain.history.entity
 
 import com.retoday.core.global.entity.BaseEntity
 import io.hypersistence.utils.hibernate.id.Tsid
-import jakarta.persistence.*
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
 import java.time.Instant
 import java.time.LocalDate
 
 @Entity
 @Table(
     indexes = [
-        Index(name = "idx_user_date", columnList = "user_id, visited_date")
+        Index(name = "idx_user_id_visited_at", columnList = "user_id, visited_at")
     ]
 )
 class History(

--- a/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
@@ -1,6 +1,6 @@
 package com.retoday.core.domain.history.repository
 
-import com.retoday.core.domain.history.dto.projection.WebsiteForCategoryAnalysis
+import com.retoday.core.domain.history.dto.projection.WebsiteStatWithCategory
 import com.retoday.core.domain.history.entity.History
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -44,12 +44,12 @@ interface HistoryRepository : JpaRepository<History, Long> {
             """,
         nativeQuery = true
     )
-    fun findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc(
+    fun findWebsiteStatsWithCategoryByUserId(
         @Param("userId")
         userId: Long,
         @Param("startedAt")
         startedAt: Instant,
         @Param("endedAt")
         endedAt: Instant
-    ): List<WebsiteForCategoryAnalysis>
+    ): List<WebsiteStatWithCategory>
 }

--- a/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
@@ -37,8 +37,8 @@ interface HistoryRepository : JpaRepository<History, Long> {
             JOIN website w ON w.id = h.website_id
             LEFT JOIN website_category wc ON wc.id = w.category_id
             WHERE h.user_id = :userId
-              AND h.visited_at < :endedAt
-              AND h.closed_at > :startedAt
+              AND h.visited_at BETWEEN DATE_SUB(:startedAt, INTERVAL 1 DAY) AND :endedAt
+              AND h.closed_at BETWEEN :startedAt AND DATE_ADD(:endedAt, INTERVAL 1 DAY)
             GROUP BY h.website_id, w.domain, w.favicon_url, wc.name
             ORDER BY stayDuration DESC
             """,

--- a/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
@@ -1,7 +1,10 @@
 package com.retoday.core.domain.history.repository
 
+import com.retoday.core.domain.history.dto.projection.WebsiteForCategoryAnalysis
 import com.retoday.core.domain.history.entity.History
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.Instant
 
 interface HistoryRepository : JpaRepository<History, Long> {
@@ -16,4 +19,36 @@ interface HistoryRepository : JpaRepository<History, Long> {
         visitedAt: Instant,
         closedAt: Instant
     ): List<History>
+
+    @Query(
+        """
+            SELECT
+                w.domain AS domain,
+                w.favicon_url AS faviconUrl,
+                wc.name AS categoryName,
+                SUM(
+                    TIMESTAMPDIFF(
+                        SECOND,
+                        GREATEST(h.visited_at, :startedAt),
+                        LEAST(h.closed_at, :endedAt)
+                    )
+                ) AS stayDuration
+            FROM history h
+            JOIN website w ON w.id = h.website_id
+            LEFT JOIN website_category wc ON wc.id = w.category_id
+            WHERE h.user_id = :userId
+              AND h.visited_at < :endedAt
+              AND h.closed_at > :startedAt
+            GROUP BY h.website_id, w.domain, w.favicon_url, wc.name
+            """,
+        nativeQuery = true
+    )
+    fun findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
+        @Param("userId")
+        userId: Long,
+        @Param("startedAt")
+        startedAt: Instant,
+        @Param("endedAt")
+        endedAt: Instant
+    ): List<WebsiteForCategoryAnalysis>
 }

--- a/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
@@ -40,10 +40,11 @@ interface HistoryRepository : JpaRepository<History, Long> {
               AND h.visited_at < :endedAt
               AND h.closed_at > :startedAt
             GROUP BY h.website_id, w.domain, w.favicon_url, wc.name
+            ORDER BY stayDuration DESC
             """,
         nativeQuery = true
     )
-    fun findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
+    fun findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc(
         @Param("userId")
         userId: Long,
         @Param("startedAt")

--- a/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
@@ -26,12 +26,14 @@ interface HistoryRepository : JpaRepository<History, Long> {
                 w.domain AS domain,
                 w.favicon_url AS faviconUrl,
                 wc.name AS categoryName,
-                SUM(
-                    TIMESTAMPDIFF(
-                        SECOND,
-                        GREATEST(h.visited_at, :startedAt),
-                        LEAST(h.closed_at, :endedAt)
-                    )
+                CAST(
+                    SUM(
+                        TIMESTAMPDIFF(
+                            SECOND,
+                            GREATEST(h.visited_at, :startedAt),
+                            LEAST(h.closed_at, :endedAt)
+                        )
+                    ) AS SIGNED
                 ) AS stayDuration
             FROM history h
             JOIN website w ON w.id = h.website_id

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
@@ -180,15 +180,15 @@ class HistoryService(
         val periodEndedAt = periodStartedAt.plus(1, ChronoUnit.DAYS)
 
         // 집계 기간 내의 방문 기록들을 웹사이트 단위로 미리 집계해서 조회한다.
-        val websiteForCategoryAnalyses =
-            historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc(
+        val websiteStatsWithCategory =
+            historyRepository.findWebsiteStatsWithCategoryByUserId(
                 userId = userId,
                 startedAt = periodStartedAt,
                 endedAt = periodEndedAt
             )
 
         val categoryAnalyses =
-            websiteForCategoryAnalyses
+            websiteStatsWithCategory
                 .groupBy { it.categoryName ?: DEFAULT_CATEGORY_NAME } // 카테고리명 기준으로 웹사이트를 집계(카테고리가 미지정은 '기타')
                 .map { (categoryName, group) ->
                     GetMyCategoryAnalysesResult.CategoryAnalysis(
@@ -209,7 +209,7 @@ class HistoryService(
 
         return GetMyCategoryAnalysesResult(
             date = query.date,
-            totalStayDuration = websiteForCategoryAnalyses.sumOf { it.stayDuration },
+            totalStayDuration = websiteStatsWithCategory.sumOf { it.stayDuration },
             categoryAnalyses = categoryAnalyses
         )
     }

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
@@ -181,7 +181,7 @@ class HistoryService(
 
         // 집계 기간 내의 방문 기록들을 웹사이트 단위로 미리 집계해서 조회한다.
         val websiteForCategoryAnalyses =
-            historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
+            historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc(
                 userId = userId,
                 startedAt = periodStartedAt,
                 endedAt = periodEndedAt
@@ -203,15 +203,9 @@ class HistoryService(
                                         faviconUrl = it.faviconUrl,
                                         stayDuration = it.stayDuration
                                     )
-                                }.sortedWith(
-                                    compareByDescending<GetMyCategoryAnalysesResult.WebsiteAnalysis> { it.stayDuration }
-                                        .thenBy { it.domain }
-                                )
+                                }
                     )
-                }.sortedWith(
-                    compareByDescending<GetMyCategoryAnalysesResult.CategoryAnalysis> { it.stayDuration }
-                        .thenBy { it.categoryName }
-                )
+                }.sortedByDescending { it.stayDuration }
 
         return GetMyCategoryAnalysesResult(
             date = query.date,

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
@@ -1,7 +1,9 @@
 package com.retoday.core.domain.history.service
 
 import com.retoday.core.domain.history.dto.command.HistoryRecordCommand
+import com.retoday.core.domain.history.dto.query.GetMyCategoryAnalysisQuery
 import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
+import com.retoday.core.domain.history.dto.result.GetMyCategoryAnalysesResult
 import com.retoday.core.domain.history.dto.result.GetMyScreenTimesResult
 import com.retoday.core.domain.history.dto.result.HistoryRecordResult
 import com.retoday.core.domain.history.entity.History
@@ -21,6 +23,10 @@ class HistoryService(
     private val websiteService: WebsiteService,
     private val pageService: PageService
 ) {
+    private companion object {
+        private const val DEFAULT_CATEGORY_NAME = "기타"
+    }
+
     @Transactional
     fun recordHistory(
         userId: Long,
@@ -76,9 +82,9 @@ class HistoryService(
             // 집계 구간과 겹치는 History([visitedAt, closedAt)와 집계 구간이 교집합을 가지는 데이터)들을 조회
             val histories =
                 historyRepository.findAllByUserIdAndVisitedAtBeforeAndClosedAtAfter(
-                    userId = userId,
-                    visitedAt = periodEndedAt,
-                    closedAt = periodStartedAt
+                    userId,
+                    periodEndedAt,
+                    periodStartedAt
                 )
 
             // 집계 구간을 period.screenTimeUnit 단위의 스크린타임들로 분할
@@ -157,6 +163,55 @@ class HistoryService(
                 screenTimes = screenTimes
             )
         }
+
+    @Transactional(readOnly = true)
+    fun getMyCategoryAnalyses(
+        userId: Long,
+        query: GetMyCategoryAnalysisQuery
+    ): GetMyCategoryAnalysesResult {
+        val profile = profileRepository.findByUserId(userId)!!
+        val periodStartedAt =
+            query.date
+                .atStartOfDay(profile.timeZone.id)
+                .toInstant()
+        val periodEndedAt = periodStartedAt.plus(1, ChronoUnit.DAYS)
+        val websiteForCategoryAnalyses =
+            historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
+                userId = userId,
+                startedAt = periodStartedAt,
+                endedAt = periodEndedAt
+            )
+        val categoryAnalyses =
+            websiteForCategoryAnalyses
+                .groupBy { it.categoryName ?: DEFAULT_CATEGORY_NAME }
+                .map { (categoryName, group) ->
+                    GetMyCategoryAnalysesResult.CategoryAnalysis(
+                        categoryName = categoryName,
+                        stayDuration = group.sumOf { it.stayDuration },
+                        websiteAnalyses =
+                            group
+                                .map {
+                                    GetMyCategoryAnalysesResult.WebsiteAnalysis(
+                                        domain = it.domain,
+                                        faviconUrl = it.faviconUrl,
+                                        stayDuration = it.stayDuration
+                                    )
+                                }.sortedWith(
+                                    compareByDescending<GetMyCategoryAnalysesResult.WebsiteAnalysis> { it.stayDuration }
+                                        .thenBy { it.domain }
+                                )
+                    )
+                }.sortedWith(
+                    compareByDescending<GetMyCategoryAnalysesResult.CategoryAnalysis> { it.stayDuration }
+                        .thenBy { it.categoryName }
+                )
+
+        return GetMyCategoryAnalysesResult(
+            date = query.date,
+            totalStayDuration = websiteForCategoryAnalyses.sumOf { it.stayDuration },
+            categoryAnalyses = categoryAnalyses
+        )
+    }
 
     private fun checkDuplicateHistory(
         userId: Long,

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/HistoryService.kt
@@ -174,23 +174,30 @@ class HistoryService(
             query.date
                 .atStartOfDay(profile.timeZone.id)
                 .toInstant()
+
+        // 카테고리 분석은 일 단위 집계이므로 집계 종료 시각을 시작 시각 + 1일로 계산
+        // 이하 집계는 [periodStartedAt, periodEndedAt) 구간 내에서 처리
         val periodEndedAt = periodStartedAt.plus(1, ChronoUnit.DAYS)
+
+        // 집계 기간 내의 방문 기록들을 웹사이트 단위로 미리 집계해서 조회한다.
         val websiteForCategoryAnalyses =
             historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
                 userId = userId,
                 startedAt = periodStartedAt,
                 endedAt = periodEndedAt
             )
+
         val categoryAnalyses =
             websiteForCategoryAnalyses
-                .groupBy { it.categoryName ?: DEFAULT_CATEGORY_NAME }
+                .groupBy { it.categoryName ?: DEFAULT_CATEGORY_NAME } // 카테고리명 기준으로 웹사이트를 집계(카테고리가 미지정은 '기타')
                 .map { (categoryName, group) ->
                     GetMyCategoryAnalysesResult.CategoryAnalysis(
                         categoryName = categoryName,
-                        stayDuration = group.sumOf { it.stayDuration },
+                        stayDuration = group.sumOf { it.stayDuration }, // 카테고리 체류시간 합산
                         websiteAnalyses =
                             group
                                 .map {
+                                    // 해당 카테고리를 가진 웹사이트 정보 및 체류시간 합산
                                     GetMyCategoryAnalysesResult.WebsiteAnalysis(
                                         domain = it.domain,
                                         faviconUrl = it.faviconUrl,

--- a/core/src/test/kotlin/com/retoday/core/domain/history/repository/CustomWebsiteRepositoryTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/history/repository/CustomWebsiteRepositoryTest.kt
@@ -3,12 +3,11 @@ package com.retoday.core.domain.history.repository
 import com.retoday.core.common.RepositoryTest
 import com.retoday.core.domain.history.entity.Website
 import com.retoday.core.domain.user.entity.User
-import com.retoday.core.domain.user.entity.UserExcludedWebsite
 import com.retoday.core.fixture.createUser
 import com.retoday.core.fixture.createUserExcludedWebsite
 import com.retoday.core.fixture.createWebsite
 import io.kotest.core.test.TestCase
-import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import org.springframework.beans.factory.annotation.Autowired
 
 class CustomWebsiteRepositoryTest : RepositoryTest() {
@@ -19,7 +18,6 @@ class CustomWebsiteRepositoryTest : RepositoryTest() {
     @Autowired
     private lateinit var customWebsiteRepository: CustomWebsiteRepositoryImpl
     private lateinit var user: User
-    private lateinit var userExcludedWebsites: List<UserExcludedWebsite>
     private lateinit var websites: List<Website>
 
     override suspend fun beforeEach(testCase: TestCase) {
@@ -31,18 +29,17 @@ class CustomWebsiteRepositoryTest : RepositoryTest() {
                 createWebsite(id = null, domain = it)
                     .save()
             }
-        userExcludedWebsites =
-            websites.map {
-                createUserExcludedWebsite(id = null, userId = user.id!!, websiteId = it.id!!)
-                    .save()
-            }
+        websites.forEach {
+            createUserExcludedWebsite(id = null, userId = user.id!!, websiteId = it.id!!)
+                .save()
+        }
     }
 
     init {
         "findAllExcludedDomainsByUserId()" {
             val excludedDomains = customWebsiteRepository.findAllExcludedDomainsByUserId(user.id!!)
 
-            excludedDomains shouldContainExactly DOMAINS
+            excludedDomains shouldContainExactlyInAnyOrder DOMAINS
         }
     }
 }

--- a/core/src/test/kotlin/com/retoday/core/domain/history/repository/HistoryRepositoryTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/history/repository/HistoryRepositoryTest.kt
@@ -13,7 +13,7 @@ class HistoryRepositoryTest : RepositoryTest() {
     private lateinit var historyRepository: HistoryRepository
 
     init {
-        "findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc()" {
+        "findWebsiteStatsWithCategoryByUserId()" {
             val userId = 1L
             val periodStartedAt = Instant.parse("2026-02-13T00:00:00Z")
             val periodEndedAt = Instant.parse("2026-02-14T00:00:00Z")
@@ -84,7 +84,7 @@ class HistoryRepositoryTest : RepositoryTest() {
             entityManager.clear()
 
             val analyses =
-                historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc(
+                historyRepository.findWebsiteStatsWithCategoryByUserId(
                     userId = userId,
                     startedAt = periodStartedAt,
                     endedAt = periodEndedAt

--- a/core/src/test/kotlin/com/retoday/core/domain/history/repository/HistoryRepositoryTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/history/repository/HistoryRepositoryTest.kt
@@ -13,7 +13,7 @@ class HistoryRepositoryTest : RepositoryTest() {
     private lateinit var historyRepository: HistoryRepository
 
     init {
-        "findWebsiteForCategoryAnalysesByUserIdAndPeriodIn()" {
+        "findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc()" {
             val userId = 1L
             val periodStartedAt = Instant.parse("2026-02-13T00:00:00Z")
             val periodEndedAt = Instant.parse("2026-02-14T00:00:00Z")
@@ -84,7 +84,7 @@ class HistoryRepositoryTest : RepositoryTest() {
             entityManager.clear()
 
             val analyses =
-                historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
+                historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc(
                     userId = userId,
                     startedAt = periodStartedAt,
                     endedAt = periodEndedAt

--- a/core/src/test/kotlin/com/retoday/core/domain/history/repository/HistoryRepositoryTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/history/repository/HistoryRepositoryTest.kt
@@ -1,0 +1,106 @@
+package com.retoday.core.domain.history.repository
+
+import com.retoday.core.common.RepositoryTest
+import com.retoday.core.fixture.*
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.Instant
+import java.time.LocalDate
+
+class HistoryRepositoryTest : RepositoryTest() {
+    @Autowired
+    private lateinit var historyRepository: HistoryRepository
+
+    init {
+        "findWebsiteForCategoryAnalysesByUserIdAndPeriodIn()" {
+            val userId = 1L
+            val periodStartedAt = Instant.parse("2026-02-13T00:00:00Z")
+            val periodEndedAt = Instant.parse("2026-02-14T00:00:00Z")
+
+            val category = createWebsiteCategory(id = null, name = "개발").save()
+            val github = createWebsite(id = null, domain = DOMAIN, categoryId = category.id).save()
+            val news = createWebsite(id = null, domain = USER_EX_DOMAIN, faviconUrl = null).save()
+            val githubId = github.id!!
+            val newsId = news.id!!
+
+            createHistory(
+                id = null,
+                userId = userId,
+                websiteId = githubId,
+                pageId = 11L,
+                visitedAt = Instant.parse("2026-02-12T23:30:00Z"),
+                closedAt = Instant.parse("2026-02-13T00:30:00Z"),
+                stayDuration = 3_600,
+                visitedDate = LocalDate.parse("2026-02-12"),
+                visitedHour = 23
+            ).save()
+            createHistory(
+                id = null,
+                userId = userId,
+                websiteId = githubId,
+                pageId = 12L,
+                visitedAt = Instant.parse("2026-02-13T01:00:00Z"),
+                closedAt = Instant.parse("2026-02-13T01:30:00Z"),
+                stayDuration = 1_800,
+                visitedDate = LocalDate.parse("2026-02-13"),
+                visitedHour = 1
+            ).save()
+            createHistory(
+                id = null,
+                userId = userId,
+                websiteId = newsId,
+                pageId = 13L,
+                visitedAt = Instant.parse("2026-02-13T23:30:00Z"),
+                closedAt = Instant.parse("2026-02-14T00:30:00Z"),
+                stayDuration = 3_600,
+                visitedDate = LocalDate.parse("2026-02-13"),
+                visitedHour = 23
+            ).save()
+            createHistory(
+                id = null,
+                userId = userId,
+                websiteId = newsId,
+                pageId = 14L,
+                visitedAt = Instant.parse("2026-02-14T01:00:00Z"),
+                closedAt = Instant.parse("2026-02-14T02:00:00Z"),
+                stayDuration = 3_600,
+                visitedDate = LocalDate.parse("2026-02-14"),
+                visitedHour = 1
+            ).save()
+            createHistory(
+                id = null,
+                userId = 2L,
+                websiteId = githubId,
+                pageId = 15L,
+                visitedAt = Instant.parse("2026-02-13T02:00:00Z"),
+                closedAt = Instant.parse("2026-02-13T03:00:00Z"),
+                stayDuration = 3_600,
+                visitedDate = LocalDate.parse("2026-02-13"),
+                visitedHour = 2
+            ).save()
+
+            entityManager.flush()
+            entityManager.clear()
+
+            val analyses =
+                historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
+                    userId = userId,
+                    startedAt = periodStartedAt,
+                    endedAt = periodEndedAt
+                )
+
+            analyses shouldHaveSize 2
+
+            val githubAnalysis = analyses.first { it.domain == DOMAIN }
+            githubAnalysis.categoryName shouldBe "개발"
+            githubAnalysis.faviconUrl shouldBe github.faviconUrl
+            githubAnalysis.stayDuration shouldBe 3_600L
+
+            val newsAnalysis = analyses.first { it.domain == USER_EX_DOMAIN }
+            newsAnalysis.faviconUrl shouldBe null
+            newsAnalysis.categoryName shouldBe null
+            newsAnalysis.stayDuration shouldBe 1_800L
+        }
+    }
+}

--- a/core/src/test/kotlin/com/retoday/core/domain/history/service/HistoryServiceTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/history/service/HistoryServiceTest.kt
@@ -1,5 +1,6 @@
 package com.retoday.core.domain.history.service
 
+import com.retoday.core.domain.history.dto.query.GetMyCategoryAnalysisQuery
 import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
 import com.retoday.core.domain.history.exception.DuplicateHistoryException
 import com.retoday.core.domain.history.exception.InvalidTimeRangeException
@@ -25,9 +26,9 @@ class HistoryServiceTest :
         val historyService =
             HistoryService(
                 historyRepository = historyRepository,
+                profileRepository = profileRepository,
                 websiteService = websiteService,
-                pageService = pageService,
-                profileRepository = profileRepository
+                pageService = pageService
             )
 
         val userId = ID
@@ -248,6 +249,57 @@ class HistoryServiceTest :
                             userId = userId,
                             visitedAt = weekEndUtc,
                             closedAt = weekStartUtc
+                        )
+                    }
+                }
+            }
+        }
+
+        Given("일간 카테고리 분석 집계가 필요할 때") {
+            val targetDate = LocalDate.parse("2026-02-13")
+            val query =
+                GetMyCategoryAnalysisQuery(
+                    date = targetDate
+                )
+            val expectedResult = createGetMyCategoryAnalysisResult(date = targetDate)
+            val profile = createProfile()
+            val dayStartUtc = Instant.parse("2026-02-12T15:00:00Z")
+            val dayEndUtc = Instant.parse("2026-02-13T15:00:00Z")
+            every { profileRepository.findByUserId(userId) } returns profile
+            every {
+                historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
+                    userId = userId,
+                    startedAt = dayStartUtc,
+                    endedAt = dayEndUtc
+                )
+            } returns
+                expectedResult.categoryAnalyses
+                    .flatMap { categoryAnalysis ->
+                        categoryAnalysis.websiteAnalyses.map { websiteAnalysis ->
+                            createWebsiteForCategoryAnalysis(
+                                domain = websiteAnalysis.domain,
+                                faviconUrl = websiteAnalysis.faviconUrl,
+                                categoryName =
+                                    if (categoryAnalysis.categoryName == "기타") {
+                                        null
+                                    } else {
+                                        categoryAnalysis.categoryName
+                                    },
+                                stayDuration = websiteAnalysis.stayDuration
+                            )
+                        }
+                    }.asReversed()
+
+            When("사용자가 본인 일간 카테고리 분석을 조회하면") {
+                val result = historyService.getMyCategoryAnalyses(userId, query)
+
+                Then("카테고리별 체류 시간과 도메인 목록이 정확하게 계산된다.") {
+                    result shouldBe expectedResult
+                    verify(exactly = 1) {
+                        historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
+                            userId = userId,
+                            startedAt = dayStartUtc,
+                            endedAt = dayEndUtc
                         )
                     }
                 }

--- a/core/src/test/kotlin/com/retoday/core/domain/history/service/HistoryServiceTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/history/service/HistoryServiceTest.kt
@@ -267,7 +267,7 @@ class HistoryServiceTest :
             val dayEndUtc = Instant.parse("2026-02-13T15:00:00Z")
             every { profileRepository.findByUserId(userId) } returns profile
             every {
-                historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
+                historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc(
                     userId = userId,
                     startedAt = dayStartUtc,
                     endedAt = dayEndUtc
@@ -288,7 +288,7 @@ class HistoryServiceTest :
                                 stayDuration = websiteAnalysis.stayDuration
                             )
                         }
-                    }.asReversed()
+                    }
 
             When("사용자가 본인 일간 카테고리 분석을 조회하면") {
                 val result = historyService.getMyCategoryAnalyses(userId, query)
@@ -296,7 +296,7 @@ class HistoryServiceTest :
                 Then("카테고리별 체류 시간과 도메인 목록이 정확하게 계산된다.") {
                     result shouldBe expectedResult
                     verify(exactly = 1) {
-                        historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodIn(
+                        historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc(
                             userId = userId,
                             startedAt = dayStartUtc,
                             endedAt = dayEndUtc

--- a/core/src/test/kotlin/com/retoday/core/domain/history/service/HistoryServiceTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/history/service/HistoryServiceTest.kt
@@ -267,7 +267,7 @@ class HistoryServiceTest :
             val dayEndUtc = Instant.parse("2026-02-13T15:00:00Z")
             every { profileRepository.findByUserId(userId) } returns profile
             every {
-                historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc(
+                historyRepository.findWebsiteStatsWithCategoryByUserId(
                     userId = userId,
                     startedAt = dayStartUtc,
                     endedAt = dayEndUtc
@@ -276,7 +276,7 @@ class HistoryServiceTest :
                 expectedResult.categoryAnalyses
                     .flatMap { categoryAnalysis ->
                         categoryAnalysis.websiteAnalyses.map { websiteAnalysis ->
-                            createWebsiteForCategoryAnalysis(
+                            createWebsiteStatWithCategory(
                                 domain = websiteAnalysis.domain,
                                 faviconUrl = websiteAnalysis.faviconUrl,
                                 categoryName =
@@ -296,7 +296,7 @@ class HistoryServiceTest :
                 Then("카테고리별 체류 시간과 도메인 목록이 정확하게 계산된다.") {
                     result shouldBe expectedResult
                     verify(exactly = 1) {
-                        historyRepository.findWebsiteForCategoryAnalysesByUserIdAndPeriodInOrderByStayDurationDesc(
+                        historyRepository.findWebsiteStatsWithCategoryByUserId(
                             userId = userId,
                             startedAt = dayStartUtc,
                             endedAt = dayEndUtc

--- a/core/src/test/resources/application.yaml
+++ b/core/src/test/resources/application.yaml
@@ -1,7 +1,4 @@
 spring:
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;;NON_KEYWORDS=USER
   jpa:
     hibernate:
       ddl-auto: create-drop

--- a/core/src/testFixtures/kotlin/com/retoday/core/common/RepositoryTest.kt
+++ b/core/src/testFixtures/kotlin/com/retoday/core/common/RepositoryTest.kt
@@ -2,14 +2,20 @@ package com.retoday.core.common
 
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.autoconfigure.KotlinJdslAutoConfiguration
 import com.retoday.core.global.config.JpaConfiguration
+import com.retoday.core.global.entity.BaseEntity
 import io.kotest.core.spec.style.StringSpec
 import jakarta.persistence.EntityManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.test.context.ContextConfiguration
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers as EnableTestContainers
 
 @DataJpaTest
+@EnableTestContainers
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(
     classes = [
@@ -18,8 +24,15 @@ import org.springframework.test.context.ContextConfiguration
     ]
 )
 abstract class RepositoryTest : StringSpec() {
+    companion object {
+        @Container
+        @ServiceConnection
+        @JvmStatic
+        private val mysql = MySQLContainer("mysql:8.0")
+    }
+
     @Autowired
     protected lateinit var entityManager: EntityManager
 
-    protected fun <T> T.save(): T = also { entityManager.persist(it) }
+    protected fun <T : BaseEntity> T.save(): T = also { entityManager.persist(it) }
 }

--- a/core/src/testFixtures/kotlin/com/retoday/core/fixture/HistoryFixtures.kt
+++ b/core/src/testFixtures/kotlin/com/retoday/core/fixture/HistoryFixtures.kt
@@ -1,7 +1,7 @@
 package com.retoday.core.fixture
 
 import com.retoday.core.domain.history.dto.command.HistoryRecordCommand
-import com.retoday.core.domain.history.dto.projection.WebsiteForCategoryAnalysis
+import com.retoday.core.domain.history.dto.projection.WebsiteStatWithCategory
 import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
 import com.retoday.core.domain.history.dto.result.GetMyCategoryAnalysesResult
 import com.retoday.core.domain.history.dto.result.GetMyScreenTimesResult
@@ -124,18 +124,18 @@ fun createGetMyCategoryAnalysisResult(date: LocalDate = LocalDate.parse("2026-02
             )
     )
 
-fun createWebsiteForCategoryAnalysis(
+fun createWebsiteStatWithCategory(
     domain: String,
     faviconUrl: String? = FAVICON_URL,
     categoryName: String? = null,
     stayDuration: Long
-): WebsiteForCategoryAnalysis =
-    object : WebsiteForCategoryAnalysis {
-        override val domain: String = domain
-        override val faviconUrl: String? = faviconUrl
-        override val categoryName: String? = categoryName
-        override val stayDuration: Long = stayDuration
-    }
+): WebsiteStatWithCategory =
+    WebsiteStatWithCategory(
+        domain = domain,
+        faviconUrl = faviconUrl,
+        categoryName = categoryName,
+        stayDuration = stayDuration
+    )
 
 fun createWebsite(
     id: Long? = WEBSITE_ID,

--- a/core/src/testFixtures/kotlin/com/retoday/core/fixture/HistoryFixtures.kt
+++ b/core/src/testFixtures/kotlin/com/retoday/core/fixture/HistoryFixtures.kt
@@ -1,12 +1,15 @@
 package com.retoday.core.fixture
 
 import com.retoday.core.domain.history.dto.command.HistoryRecordCommand
+import com.retoday.core.domain.history.dto.projection.WebsiteForCategoryAnalysis
 import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
+import com.retoday.core.domain.history.dto.result.GetMyCategoryAnalysesResult
 import com.retoday.core.domain.history.dto.result.GetMyScreenTimesResult
 import com.retoday.core.domain.history.dto.result.HistoryRecordResult
 import com.retoday.core.domain.history.entity.History
 import com.retoday.core.domain.history.entity.Page
 import com.retoday.core.domain.history.entity.Website
+import com.retoday.core.domain.history.entity.WebsiteCategory
 import java.time.Instant
 import java.time.LocalDate
 
@@ -71,6 +74,69 @@ fun createGetMyWeeklyScreenTimesResult(): GetMyScreenTimesResult =
                 }
     )
 
+fun createGetMyCategoryAnalysisResult(date: LocalDate = LocalDate.parse("2026-02-13")): GetMyCategoryAnalysesResult =
+    GetMyCategoryAnalysesResult(
+        date = date,
+        totalStayDuration = 16_200L,
+        categoryAnalyses =
+            listOf(
+                GetMyCategoryAnalysesResult.CategoryAnalysis(
+                    categoryName = "개발",
+                    stayDuration = 9_000L,
+                    websiteAnalyses =
+                        listOf(
+                            GetMyCategoryAnalysesResult.WebsiteAnalysis(
+                                domain = DOMAIN,
+                                faviconUrl = FAVICON_URL,
+                                stayDuration = 5_400L
+                            ),
+                            GetMyCategoryAnalysesResult.WebsiteAnalysis(
+                                domain = "stackoverflow.com",
+                                faviconUrl = "https://stackoverflow.com/favicon.ico",
+                                stayDuration = 3_600L
+                            )
+                        )
+                ),
+                GetMyCategoryAnalysesResult.CategoryAnalysis(
+                    categoryName = "콘텐츠",
+                    stayDuration = 5_400L,
+                    websiteAnalyses =
+                        listOf(
+                            GetMyCategoryAnalysesResult.WebsiteAnalysis(
+                                domain = "youtube.com",
+                                faviconUrl = "https://www.youtube.com/favicon.ico",
+                                stayDuration = 5_400L
+                            )
+                        )
+                ),
+                GetMyCategoryAnalysesResult.CategoryAnalysis(
+                    categoryName = "기타",
+                    stayDuration = 1_800L,
+                    websiteAnalyses =
+                        listOf(
+                            GetMyCategoryAnalysesResult.WebsiteAnalysis(
+                                domain = "uncategorized.com",
+                                faviconUrl = "https://uncategorized.com/favicon.ico",
+                                stayDuration = 1_800L
+                            )
+                        )
+                )
+            )
+    )
+
+fun createWebsiteForCategoryAnalysis(
+    domain: String,
+    faviconUrl: String? = FAVICON_URL,
+    categoryName: String? = null,
+    stayDuration: Long
+): WebsiteForCategoryAnalysis =
+    object : WebsiteForCategoryAnalysis {
+        override val domain: String = domain
+        override val faviconUrl: String? = faviconUrl
+        override val categoryName: String? = categoryName
+        override val stayDuration: Long = stayDuration
+    }
+
 fun createWebsite(
     id: Long? = WEBSITE_ID,
     domain: String = DOMAIN,
@@ -82,6 +148,15 @@ fun createWebsite(
         domain = domain,
         categoryId = categoryId,
         faviconUrl = faviconUrl
+    )
+
+fun createWebsiteCategory(
+    id: Long? = ID,
+    name: String = "개발"
+): WebsiteCategory =
+    WebsiteCategory(
+        id = id,
+        name = name
     )
 
 fun createPage(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,10 +24,6 @@ jdsl = "3.7.2"
 # OpenAPI
 restdocs-api-spec = "0.19.4"
 
-# Gemini
-gemini = "1.38.0"
-jackson = "2.17.2"
-
 [plugins]
 
 # Java
@@ -65,6 +61,7 @@ spring-test = { group = "org.springframework.boot", name = "spring-boot-starter-
 spring-restdocs-webtestclient = { group = "org.springframework.restdocs", name = "spring-restdocs-webtestclient" }
 spring-batch = { group = "org.springframework.boot", name = "spring-boot-starter-batch" }
 spring-actuator = { group = "org.springframework.boot", name = "spring-boot-starter-actuator" }
+spring-testcontainers = { group = "org.springframework.boot", name = "spring-boot-testcontainers" }
 
 # JWT
 jjwt-api = { group = "io.jsonwebtoken", name = "jjwt-api", version.ref = "jwt" }
@@ -101,11 +98,12 @@ restdocs-api-spec = { group = "com.epages", name = "restdocs-api-spec", version.
 restdocs-api-spec-webtestclient = { group = "com.epages", name = "restdocs-api-spec-webtestclient", version.ref = "restdocs-api-spec" }
 springdoc-openapi = { group = "org.springdoc", name = "springdoc-openapi-starter-webmvc-ui", version = "2.8.9" }
 
-# Gemini API
-gemini-google = { group = "com.google.genai", name = "google-genai", version.ref = "gemini" }
+# Test Containers
+test-containers-junit = { group = "org.testcontainers", name = "junit-jupiter" }
+test-containers-mysql = { group = "org.testcontainers", name = "mysql" }
 
-# Jackson Kotlin
-jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
+# Google
+google-gemini = { group = "com.google.genai", name = "google-genai", version = "1.38.0" }
 
 [bundles]
 test = [
@@ -137,4 +135,9 @@ jdsl = [
     "jdsl-dsl",
     "jdsl-render",
     "jdsl-jpa"
+]
+test-containers = [
+    "spring-testcontainers",
+    "test-containers-junit",
+    "test-containers-mysql"
 ]


### PR DESCRIPTION
## 작업 내용

- 카테고리 분석 조회 기능 구현
- 문서화 코드 리팩토링

## 참고

- 비동기 처리 지연으로 카테고리가 아직 배정되지 않은 웹사이트의 경우, '기타'로 집계하도록 했습니다.
- 복합 인덱스(`idx_user_date(user_id, visited_at)`)는 정상적으로 사용되지만, 구조적으로 `visited_at` 인덱스 스캔 범위가 넓다는 한계가 있습니다.
  - 이후 논의를 통해 요구사항에서 하나의 탭 기록(`history`)이 이틀 이상 지속될 수 없다는 제약 조건이 추가된다면, `BETWEEN `조건을 활용하여 스캔 범위를 제한함으로써 성능을 개선할 수 있습니다.
  - 참고로 매일 평균 100명의 유저가 20개의 `history`를 1년간 생성한다고 가정했을 때(총 약 50만 건), 쿼리 실행 시간은 `BETWEEN` 조건을 적용하지 않으면 약 13ms, 적용하면 약 0.5ms로 차이가 나는 것을 확인했습니다.

## 관련 이슈

- close #59
