### PR TITLE
[#63] 카테고리 자동 할당 기능 구현

### DIFF
--- a/core/src/main/kotlin/com/retoday/core/domain/history/event/WebsiteCategoryClassificationEvent.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/event/WebsiteCategoryClassificationEvent.kt
@@ -1,0 +1,6 @@
+package com.retoday.core.domain.history.event
+
+data class WebsiteCategoryClassificationEvent(
+    val websiteId: Long,
+    val domain: String
+)

--- a/core/src/main/kotlin/com/retoday/core/domain/history/event/WebsiteCategoryClassificationEventListener.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/event/WebsiteCategoryClassificationEventListener.kt
@@ -1,0 +1,26 @@
+package com.retoday.core.domain.history.event
+
+import com.retoday.core.domain.history.repository.WebsiteRepository
+import org.springframework.context.event.EventListener
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class WebsiteCategoryClassificationEventListener(
+    private val websiteRepository: WebsiteRepository
+) {
+
+    @Async
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleClassificationEvent(event: WebsiteCategoryClassificationEvent) {
+        websiteRepository.findByIdOrNull(event.websiteId)
+            ?.takeIf { it.categoryId == null }
+            ?: return
+
+        // TODO: AI 분류 요청
+    }
+}

--- a/core/src/main/kotlin/com/retoday/core/domain/history/event/WebsiteCategoryClassificationEventListener.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/event/WebsiteCategoryClassificationEventListener.kt
@@ -1,23 +1,24 @@
 package com.retoday.core.domain.history.event
 
 import com.retoday.core.domain.history.repository.WebsiteRepository
-import org.springframework.context.event.EventListener
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 
 @Component
 class WebsiteCategoryClassificationEventListener(
     private val websiteRepository: WebsiteRepository
 ) {
-
     @Async
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun handleClassificationEvent(event: WebsiteCategoryClassificationEvent) {
-        websiteRepository.findByIdOrNull(event.websiteId)
+        websiteRepository
+            .findByIdOrNull(event.websiteId)
             ?.takeIf { it.categoryId == null }
             ?: return
 

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/WebsiteService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/WebsiteService.kt
@@ -1,24 +1,29 @@
 package com.retoday.core.domain.history.service
 
 import com.retoday.core.domain.history.entity.Website
+import com.retoday.core.domain.history.event.WebsiteCategoryClassificationEvent
 import com.retoday.core.domain.history.repository.WebsiteRepository
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class WebsiteService(
-    private val websiteRepository: WebsiteRepository
+    private val websiteRepository: WebsiteRepository,
+    private val eventPublisher: ApplicationEventPublisher
 ) {
     @Transactional
-    fun findOrCreate(
-        domain: String,
-        faviconUrl: String?
-    ) = websiteRepository.findByDomain(domain)
-        ?: websiteRepository.save(
+    fun findOrCreate(domain: String, faviconUrl: String?): Website =
+        websiteRepository.findByDomain(domain) ?: run {
             Website(
                 domain = domain,
                 categoryId = null,
                 faviconUrl = faviconUrl
-            )
-        )
+            ).let { websiteRepository.save(it) }
+                .also {
+                    eventPublisher.publishEvent(
+                        WebsiteCategoryClassificationEvent(it.id!!, domain)
+                    )
+                }
+        }
 }

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/WebsiteService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/WebsiteService.kt
@@ -13,7 +13,10 @@ class WebsiteService(
     private val eventPublisher: ApplicationEventPublisher
 ) {
     @Transactional
-    fun findOrCreate(domain: String, faviconUrl: String?): Website =
+    fun findOrCreate(
+        domain: String,
+        faviconUrl: String?
+    ): Website =
         websiteRepository.findByDomain(domain) ?: run {
             Website(
                 domain = domain,

--- a/core/src/main/kotlin/com/retoday/core/global/config/AsyncConfiguration.kt
+++ b/core/src/main/kotlin/com/retoday/core/global/config/AsyncConfiguration.kt
@@ -5,5 +5,4 @@ import org.springframework.scheduling.annotation.EnableAsync
 
 @Configuration
 @EnableAsync
-class AsyncConfiguration {
-}
+class AsyncConfiguration

--- a/core/src/main/kotlin/com/retoday/core/global/config/AsyncConfiguration.kt
+++ b/core/src/main/kotlin/com/retoday/core/global/config/AsyncConfiguration.kt
@@ -1,0 +1,9 @@
+package com.retoday.core.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+
+@Configuration
+@EnableAsync
+class AsyncConfiguration {
+}


### PR DESCRIPTION
## 작업 내용

-  새 Website 생성 시 `WebsiteCategoryClassificationEvent` 발행

## 참고

- 이미 카테고리가 할당된 Website는 필터링 및 이벤트 발행 X
- TODO: AI 카테고리 분류 API 호출 로직 구현 (담당: @mjk25)

## 관련 이슈

- close #63 
