### PR TITLE
[#71] 방문기록 저장 API 최적화

### DIFF
--- a/api/src/main/kotlin/com/retoday/api/domain/history/controller/HistoryController.kt
+++ b/api/src/main/kotlin/com/retoday/api/domain/history/controller/HistoryController.kt
@@ -5,7 +5,9 @@ import com.retoday.api.domain.history.dto.response.GetMyScreenTimesResponse
 import com.retoday.api.domain.history.dto.response.HistoryRecordResponse
 import com.retoday.api.global.annotation.AuthenticationId
 import com.retoday.core.domain.history.dto.query.GetMyScreenTimesQuery
+import com.retoday.core.domain.history.exception.RateLimitExceededException
 import com.retoday.core.domain.history.service.HistoryService
+import com.retoday.core.global.ratelimit.RateLimiter
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDate
@@ -13,7 +15,8 @@ import java.time.LocalDate
 @RestController
 @RequestMapping("/api/v1")
 class HistoryController(
-    private val historyService: HistoryService
+    private val historyService: HistoryService,
+    private val rateLimiter: RateLimiter
 ) {
     @PostMapping("/histories")
     fun recordHistory(
@@ -22,10 +25,14 @@ class HistoryController(
         @Valid
         @RequestBody
         request: HistoryRecordRequest
-    ): HistoryRecordResponse =
-        historyService
+    ): HistoryRecordResponse {
+        rateLimiter
+            .checkHistoryExceeded(userId)
+            ?.let { retryAfter -> throw RateLimitExceededException(userId, retryAfter) }
+        return historyService
             .recordHistory(userId, request.toCommand())
             .let { HistoryRecordResponse.from(it) }
+    }
 
     @GetMapping("/users/me/screen-times")
     fun getMyScreenTimes(

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/PageService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/PageService.kt
@@ -2,6 +2,7 @@ package com.retoday.core.domain.history.service
 
 import com.retoday.core.domain.history.entity.Page
 import com.retoday.core.domain.history.repository.PageRepository
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,13 +16,10 @@ class PageService(
         url: String,
         title: String?,
         description: String?
-    ) = pageRepository.findByUrl(url)
-        ?: pageRepository.save(
-            Page(
-                websiteId = websiteId,
-                url = url,
-                title = title,
-                description = description
-            )
-        )
+    ): Page =
+        pageRepository.findByUrl(url) ?: try {
+            pageRepository.save(Page(websiteId = websiteId, url = url, title = title, description = description))
+        } catch (e: DataIntegrityViolationException) {
+            pageRepository.findByUrl(url)!!
+        }
 }

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/WebsiteService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/WebsiteService.kt
@@ -4,6 +4,7 @@ import com.retoday.core.domain.history.entity.Website
 import com.retoday.core.domain.history.event.WebsiteCategoryClassificationEvent
 import com.retoday.core.domain.history.repository.WebsiteRepository
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,16 +18,11 @@ class WebsiteService(
         domain: String,
         faviconUrl: String?
     ): Website =
-        websiteRepository.findByDomain(domain) ?: run {
-            Website(
-                domain = domain,
-                categoryId = null,
-                faviconUrl = faviconUrl
-            ).let { websiteRepository.save(it) }
-                .also {
-                    eventPublisher.publishEvent(
-                        WebsiteCategoryClassificationEvent(it.id!!, domain)
-                    )
-                }
+        websiteRepository.findByDomain(domain) ?: try {
+            websiteRepository
+                .save(Website(domain = domain, faviconUrl = faviconUrl))
+                .also { eventPublisher.publishEvent(WebsiteCategoryClassificationEvent(it.id!!, domain)) }
+        } catch (e: DataIntegrityViolationException) {
+            websiteRepository.findByDomain(domain)!!
         }
 }

--- a/core/src/main/kotlin/com/retoday/core/global/ratelimit/RateLimiter.kt
+++ b/core/src/main/kotlin/com/retoday/core/global/ratelimit/RateLimiter.kt
@@ -1,0 +1,40 @@
+package com.retoday.core.global.ratelimit
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class RateLimiter(
+    private val redisTemplate: StringRedisTemplate
+) {
+    companion object {
+        private const val HISTORY_LIMIT = 10L
+        private val HISTORY_WINDOW = Duration.ofMinutes(1)
+    }
+
+    private val script =
+        RedisScript.of(
+            """
+            local count = redis.call('INCR', KEYS[1])
+            if count == 1 then
+                redis.call('EXPIRE', KEYS[1], ARGV[1])
+            end
+            return {count, redis.call('TTL', KEYS[1])}
+            """.trimIndent(),
+            List::class.java
+        )
+
+    fun checkHistoryExceeded(userId: Long): Long? =
+        runCatching {
+            val result =
+                redisTemplate
+                    .execute(script, listOf("rate:history:$userId"), HISTORY_WINDOW.seconds.toString())
+                    .uncheckedCast<List<Long>>() ?: return null
+            if (result[0] > HISTORY_LIMIT) result[1] else null
+        }.getOrNull()
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> Any?.uncheckedCast(): T? = this as? T
+}


### PR DESCRIPTION
## 작업 내용

- RateLimiter 컴포넌트 추가
- Rate Limit 체크 추가
- Website, Page 중복 저장 예외 처리

## 참고

- 사용자별(userId) 분당 요청 10건 초과 시 429 상태코드와 함께 재시도 시점(retryAfterSeconds)을 반환합니다.
    - 분당 10건으로 정한 이유는 하나의 History를 기준으로 체류시간이 최소 10초인 점을 감안하여 1분에 최대 6~7건까지의 저장 요청이 들어올수 있기 때문입니다.
- INCR 직후 서버 장애 시 EXPIRE가 설정되지 않아 해당 키가 영구적으로 남아 사용자가 영원히 차단되는 문제가 발생할 수 있기 때문에 하나의 Lua 스크립트로 원자적으로 묶었습니다.
- AOP 방식도 고려했었으나 Rate Limiting 적용 대상이 recordHistory 뿐이라 별도 의존성 추가 없이 Controller에서 직접 호출하는 방식을 선택했습니다. 적용 대상이 늘어나는 시점에 AOP로 전환을 고려 중이니 추가 의견 있으시다면 피드백 부탁드립니다. (시간이 난다면 brute-force 공격을 방지하기 위해 로그인 쪽에도 Rate Limiting을 적용해도 좋을 것 같긴 합니다.)

## 관련 이슈

- close #71 