### PR TITLE
[#84] 초기 Website 데이터 faviconUrl 빈값 처리

### DIFF
--- a/core/src/main/kotlin/com/retoday/core/domain/history/entity/Website.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/entity/Website.kt
@@ -20,4 +20,8 @@ class Website(
     fun updateCategory(newCategoryId: Long?) {
         this.categoryId = newCategoryId
     }
+
+    fun updateFaviconUrl(newFaviconUrl: String) {
+        this.faviconUrl = newFaviconUrl
+    }
 }

--- a/core/src/main/kotlin/com/retoday/core/domain/history/service/WebsiteService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/service/WebsiteService.kt
@@ -18,7 +18,13 @@ class WebsiteService(
         domain: String,
         faviconUrl: String?
     ): Website =
-        websiteRepository.findByDomain(domain) ?: try {
+        websiteRepository
+            .findByDomain(domain)
+            ?.also { website ->
+                if (website.faviconUrl == null && faviconUrl != null) {
+                    website.updateFaviconUrl(faviconUrl)
+                }
+            } ?: try {
             websiteRepository
                 .save(Website(domain = domain, faviconUrl = faviconUrl))
                 .also { eventPublisher.publishEvent(WebsiteCategoryClassificationEvent(it.id!!, domain)) }


### PR DESCRIPTION
## 작업 내용

- domain이 이미 존재하지만 faviconUrl이 null인 경우 프론트에서 보내준 값으로 업데이트함

## 관련 이슈

- close #84 
