### PR TITLE
[#107] 카테고리 분석 기능 개선

### DIFF
--- a/core/src/main/kotlin/com/retoday/core/domain/history/entity/History.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/entity/History.kt
@@ -11,7 +11,8 @@ import java.time.Instant
 @Entity
 @Table(
     indexes = [
-        Index(name = "idx_user_id_visited_at", columnList = "user_id, visited_at")
+        Index(name = "idx_user_id_visited_at", columnList = "user_id, visited_at"),
+        Index(name = "idx_user_id_closed_at", columnList = "user_id, closed_at")
     ]
 )
 class History(

--- a/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/history/repository/HistoryRepository.kt
@@ -111,9 +111,9 @@ interface HistoryRepository : JpaRepository<History, Long> {
             JOIN website w ON w.id = h.website_id
             LEFT JOIN website_category wc ON wc.id = w.category_id
             WHERE h.user_id = :userId
-              AND h.visited_at BETWEEN DATE_SUB(:startedAt, INTERVAL 1 DAY) AND :endedAt
-              AND h.closed_at BETWEEN :startedAt AND DATE_ADD(:endedAt, INTERVAL 1 DAY)
-            GROUP BY h.website_id, w.domain, w.favicon_url, wc.name
+              AND h.visited_at < :endedAt
+              AND h.closed_at > :startedAt
+            GROUP BY h.website_id
             ORDER BY stayDuration DESC
         """,
         nativeQuery = true


### PR DESCRIPTION
## 작업 내용

- 카테고리 분석 기능 정확도 개선
- 카테고리 분석에 사용되는 쿼리 성능 개선

## 참고

- 48시간 넘게 활성화된 탭은 극단적인 예시지만, 통계 기능엔 정확도가 중요하다고 판단해서 기존의 48시간 범위 제한을 없앴습니다.
  - 대신 복합 인덱스(`user_id, closed_at`)를 추가해 처음에 사용하던 쿼리 성능을 크게 향상시켰습니다.
  물론, 어떠한 인덱스도 range scan 범위가 넓어지게 되는 중간 날짜(2024년부터 2026년에 걸쳐 `history`가 존재하는 경우, 2025년 6월)에는 성능이 좋지 않다는 한계가 있습니다.
- 연간 하루 평균 20개의 방문 기록을 생성하는 테스트 데이터 기준(버퍼 풀 워밍업)
  - 3년 기간 전체 조회 평균 쿼리 실행 시간 50ms → 20ms 개선
  - 자주 사용되는 오늘 기준 조회 평균 실행 시간 134ms → 0.5ms 개선(100회 측정 평균)

## 관련 이슈

- close #107
