### PR TITLE
[#117] 다국어 AI 리캡 

### DIFF
--- a/api/src/main/kotlin/com/retoday/api/domain/user/controller/UserController.kt
+++ b/api/src/main/kotlin/com/retoday/api/domain/user/controller/UserController.kt
@@ -2,12 +2,14 @@ package com.retoday.api.domain.user.controller
 
 import com.retoday.api.domain.user.dto.request.AddMyExcludedDomainRequest
 import com.retoday.api.domain.user.dto.request.DeleteMyExcludedDomainRequest
+import com.retoday.api.domain.user.dto.request.UpdateMyLanguageRequest
 import com.retoday.api.domain.user.dto.response.GetMyProfileResponse
 import com.retoday.api.global.annotation.AuthenticationId
 import com.retoday.core.domain.user.service.UserService
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -47,5 +49,16 @@ class UserController(
         request: DeleteMyExcludedDomainRequest
     ) {
         userService.deleteMyExcludedDomain(userId, request.domain)
+    }
+
+    @PatchMapping("/me/profiles/language")
+    fun updateMyLanguage(
+        @AuthenticationId
+        userId: Long,
+        @Valid
+        @RequestBody
+        request: UpdateMyLanguageRequest
+    ) {
+        userService.updateMyLanguage(userId, request.language)
     }
 }

--- a/api/src/main/kotlin/com/retoday/api/domain/user/dto/response/GetMyProfileResponse.kt
+++ b/api/src/main/kotlin/com/retoday/api/domain/user/dto/response/GetMyProfileResponse.kt
@@ -1,6 +1,7 @@
 package com.retoday.api.domain.user.dto.response
 
 import com.retoday.core.domain.user.dto.result.GetMyProfileResult
+import com.retoday.core.domain.user.entity.Language
 import com.retoday.core.domain.user.entity.TimeZone
 import java.time.LocalTime
 
@@ -12,6 +13,7 @@ data class GetMyProfileResponse(
     val imageUrl: String,
     val timeZone: TimeZone,
     val recapPeriod: LocalTime?,
+    val language: Language,
     val excludedDomains: List<String>
 ) {
     companion object {
@@ -25,6 +27,7 @@ data class GetMyProfileResponse(
                     imageUrl = imageUrl,
                     timeZone = timeZone,
                     recapPeriod = recapPeriod,
+                    language = language,
                     excludedDomains = excludedDomains
                 )
             }

--- a/api/src/test/kotlin/com/retoday/api/domain/user/UserControllerTest.kt
+++ b/api/src/test/kotlin/com/retoday/api/domain/user/UserControllerTest.kt
@@ -5,6 +5,7 @@ import com.retoday.api.common.ControllerTest
 import com.retoday.api.domain.user.controller.UserController
 import com.retoday.api.domain.user.dto.request.AddMyExcludedDomainRequest
 import com.retoday.api.domain.user.dto.request.DeleteMyExcludedDomainRequest
+import com.retoday.api.domain.user.dto.request.UpdateMyLanguageRequest
 import com.retoday.api.domain.user.dto.response.GetMyProfileResponse
 import com.retoday.api.extension.document
 import com.retoday.api.extension.expectBody
@@ -15,6 +16,8 @@ import com.retoday.api.snippet.addMyExcludedDomainRequestFields
 import com.retoday.api.snippet.deleteMyExcludedDomainRequestFields
 import com.retoday.api.snippet.errorResponseFields
 import com.retoday.api.snippet.getMyProfileResponseFields
+import com.retoday.api.snippet.updateMyLanguageRequestFields
+import com.retoday.core.domain.user.entity.Language
 import com.retoday.core.domain.user.exception.ExcludedDomainAlreadyExistsException
 import com.retoday.core.domain.user.service.UserService
 import com.retoday.core.fixture.createGetMyProfileResult
@@ -152,6 +155,50 @@ class UserControllerTest : ControllerTest() {
                         .expectBody(GetMyProfileResponse.from(result))
                         .document("내 프로필 조회 성공(200)") {
                             responseBody(getMyProfileResponseFields)
+                        }
+                }
+            }
+        }
+
+        describe("updateMyLanguage()은") {
+            val requestBody = UpdateMyLanguageRequest(language = Language.EN)
+            val request =
+                webClient
+                    .patch()
+                    .uri("/users/me/profiles/language")
+                    .bodyValue(requestBody)
+                    .withAuthentication()
+
+            context("유효한 요청이 주어진 경우") {
+                every { userService.updateMyLanguage(any(), any()) } returns Unit
+
+                it("상태 코드 200을 반환한다.") {
+                    request
+                        .exchange()
+                        .expectStatus(200)
+                        .expectBody<Void>()
+                        .document("내 리캡 언어 변경 성공(200)") {
+                            requestBody(updateMyLanguageRequestFields)
+                        }
+                }
+            }
+
+            context("리캡 언어 값이 올바르지 않은 경우") {
+                val invalidRequest =
+                    webClient
+                        .patch()
+                        .uri("/users/me/profiles/language")
+                        .bodyValue(mapOf("language" to "FR"))
+                        .withAuthentication()
+
+                it("상태 코드 400과 ErrorResponse를 반환한다.") {
+                    invalidRequest
+                        .exchange()
+                        .expectStatus(400)
+                        .expectError()
+                        .document("내 리캡 언어 변경 실패 - 유효하지 않은 리캡 언어(400)") {
+                            requestBody(updateMyLanguageRequestFields)
+                            responseBody(errorResponseFields)
                         }
                 }
             }

--- a/api/src/testFixtures/kotlin/com/retoday/api/snippet/UserSnippets.kt
+++ b/api/src/testFixtures/kotlin/com/retoday/api/snippet/UserSnippets.kt
@@ -25,5 +25,6 @@ val getMyProfileResponseFields =
         GetMyProfileResponse::imageUrl desc "프로필 이미지 URL",
         GetMyProfileResponse::timeZone desc "타임존",
         GetMyProfileResponse::recapPeriod desc "리캡 생성 주기",
+        GetMyProfileResponse::language desc "리캡 언어(KO, EN, JA)",
         GetMyProfileResponse::excludedDomains desc "예외 도메인 리스트"
     )

--- a/api/src/testFixtures/kotlin/com/retoday/api/snippet/UserSnippets.kt
+++ b/api/src/testFixtures/kotlin/com/retoday/api/snippet/UserSnippets.kt
@@ -2,6 +2,7 @@ package com.retoday.api.snippet
 
 import com.retoday.api.domain.user.dto.request.AddMyExcludedDomainRequest
 import com.retoday.api.domain.user.dto.request.DeleteMyExcludedDomainRequest
+import com.retoday.api.domain.user.dto.request.UpdateMyLanguageRequest
 import com.retoday.api.domain.user.dto.response.GetMyProfileResponse
 import com.retoday.api.extension.desc
 import com.retoday.api.extension.fieldsOf
@@ -16,6 +17,11 @@ val deleteMyExcludedDomainRequestFields =
         DeleteMyExcludedDomainRequest::domain desc "예외 처리에서 제거할 도메인"
     )
 
+val updateMyLanguageRequestFields =
+    fieldsOf(
+        UpdateMyLanguageRequest::language desc "언어(KO, EN, JA)"
+    )
+
 val getMyProfileResponseFields =
     fieldsOf(
         GetMyProfileResponse::id desc "식별자",
@@ -25,6 +31,6 @@ val getMyProfileResponseFields =
         GetMyProfileResponse::imageUrl desc "프로필 이미지 URL",
         GetMyProfileResponse::timeZone desc "타임존",
         GetMyProfileResponse::recapPeriod desc "리캡 생성 주기",
-        GetMyProfileResponse::language desc "리캡 언어(KO, EN, JA)",
+        GetMyProfileResponse::language desc "언어(KO, EN, JA)",
         GetMyProfileResponse::excludedDomains desc "예외 도메인 리스트"
     )

--- a/core/src/main/kotlin/com/retoday/core/domain/recap/client/GeminiClient.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/recap/client/GeminiClient.kt
@@ -9,6 +9,7 @@ import com.retoday.core.domain.recap.component.RecapType
 import com.retoday.core.domain.recap.dto.request.GenerateRecapRequest
 import com.retoday.core.domain.recap.dto.request.RecapPayload
 import com.retoday.core.domain.recap.exception.RecapResponseEmptyException
+import com.retoday.core.domain.user.entity.Language
 import com.retoday.core.global.annotation.Client
 import org.springframework.beans.factory.annotation.Value
 import com.google.genai.Client as GeminiClient
@@ -37,7 +38,14 @@ class GeminiClient(
         responseClass: Class<T>
     ): T {
         request.validatePayloadType()
-        val instruction = promptManager.getDailyRecapPrompt(request.type, mapOf("nickname" to request.nickname))
+        val instruction =
+            promptManager.getDailyRecapPrompt(
+                request.type,
+                mapOf(
+                    "nickname" to request.nickname,
+                    "language" to request.language.toPromptLanguage()
+                )
+            )
         val userDataJson =
             objectMapper.writeValueAsString(
                 when (val payload = request.payload) {
@@ -73,4 +81,11 @@ class GeminiClient(
             RecapType.TOPIC -> require(payload is RecapPayload.Activities)
         }
     }
+
+    private fun Language.toPromptLanguage(): String =
+        when (this) {
+            Language.KO -> "Korean"
+            Language.EN -> "English"
+            Language.JA -> "Japanese"
+        }
 }

--- a/core/src/main/kotlin/com/retoday/core/domain/recap/dto/request/GenerateRecapRequest.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/recap/dto/request/GenerateRecapRequest.kt
@@ -1,6 +1,7 @@
 package com.retoday.core.domain.recap.dto.request
 
 import com.retoday.core.domain.recap.component.RecapType
+import com.retoday.core.domain.user.entity.Language
 
 sealed interface RecapPayload {
     data class Activities(
@@ -15,5 +16,6 @@ sealed interface RecapPayload {
 data class GenerateRecapRequest(
     val type: RecapType,
     val nickname: String,
+    val language: Language,
     val payload: RecapPayload
 )

--- a/core/src/main/kotlin/com/retoday/core/domain/recap/service/RecapService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/recap/service/RecapService.kt
@@ -25,6 +25,7 @@ import com.retoday.core.domain.recap.repository.RecapRepository
 import com.retoday.core.domain.recap.repository.SectionRepository
 import com.retoday.core.domain.recap.repository.TimelineRepository
 import com.retoday.core.domain.recap.repository.TopicRepository
+import com.retoday.core.domain.user.entity.Language
 import com.retoday.core.domain.user.repository.ProfileRepository
 import com.retoday.core.global.extension.transaction
 import org.springframework.stereotype.Service
@@ -88,19 +89,20 @@ class RecapService(
         if (activityProjections.isEmpty()) return
         val activityRequests = activityProjections.map { it.toRequest() }
         val name = profile.firstName
+        val language = profile.language
         val zoneId = profile.timeZone.id
 
         val timelineProjections = historyRepository.findUserTimelinesForRecap(userId, startedAt, endedAt)
         val firstVisitedAt = timelineProjections.mapNotNull { it.visitedAt }.minOrNull() ?: startedAt
         val lastClosedAt = timelineProjections.mapNotNull { it.closedAt }.maxOrNull() ?: endedAt
 
-        val recapResponse = generateRecap(name, activityRequests)
-        val topicResponse = generateTopics(name, activityRequests)
+        val recapResponse = generateRecap(name, language, activityRequests)
+        val topicResponse = generateTopics(name, language, activityRequests)
 
         var timelineResponse = GeminiTimelineResponse()
         if (timelineProjections.isNotEmpty()) {
             val timelineRequests = timelineProjections.map { it.toRequest() }
-            timelineResponse = generateRecapTimeline(name, timelineRequests)
+            timelineResponse = generateRecapTimeline(name, language, timelineRequests)
         }
 
         val categoryAnalyses =
@@ -228,11 +230,13 @@ class RecapService(
     // AI Generation Methods
     fun generateRecap(
         name: String,
+        language: Language,
         activities: List<UserActivityRequest>
     ) = recapAIClient.generate(
         GenerateRecapRequest(
             type = RecapType.TODAY_RECAP,
             nickname = name,
+            language = language,
             payload = RecapPayload.Activities(activities)
         ),
         GeminiRecapResponse::class.java
@@ -240,11 +244,13 @@ class RecapService(
 
     fun generateRecapTimeline(
         name: String,
+        language: Language,
         activities: List<UserTimelineRequest>
     ) = recapAIClient.generate(
         GenerateRecapRequest(
             type = RecapType.TIMELINE,
             nickname = name,
+            language = language,
             payload = RecapPayload.Timelines(activities)
         ),
         GeminiTimelineResponse::class.java
@@ -252,11 +258,13 @@ class RecapService(
 
     fun generateTopics(
         name: String,
+        language: Language,
         activities: List<UserActivityRequest>
     ) = recapAIClient.generate(
         GenerateRecapRequest(
             type = RecapType.TOPIC,
             nickname = name,
+            language = language,
             payload = RecapPayload.Activities(activities)
         ),
         GeminiTopicResponse::class.java

--- a/core/src/main/kotlin/com/retoday/core/domain/user/dto/projection/ProfileWithEmailProjection.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/user/dto/projection/ProfileWithEmailProjection.kt
@@ -1,5 +1,6 @@
 package com.retoday.core.domain.user.dto.projection
 
+import com.retoday.core.domain.user.entity.Language
 import com.retoday.core.domain.user.entity.TimeZone
 import java.time.Instant
 import java.time.LocalTime
@@ -12,6 +13,7 @@ data class ProfileWithEmailProjection(
     val imageUrl: String,
     val timeZone: TimeZone,
     val recapPeriod: LocalTime?,
+    val language: Language,
     val createdAt: Instant,
     val updatedAt: Instant?,
     val deletedAt: Instant?,

--- a/core/src/main/kotlin/com/retoday/core/domain/user/dto/result/GetMyProfileResult.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/user/dto/result/GetMyProfileResult.kt
@@ -1,6 +1,7 @@
 package com.retoday.core.domain.user.dto.result
 
 import com.retoday.core.domain.user.dto.projection.ProfileWithEmailProjection
+import com.retoday.core.domain.user.entity.Language
 import com.retoday.core.domain.user.entity.TimeZone
 import java.time.LocalTime
 
@@ -12,6 +13,7 @@ data class GetMyProfileResult(
     val imageUrl: String,
     val timeZone: TimeZone,
     val recapPeriod: LocalTime?,
+    val language: Language,
     val excludedDomains: List<String>
 ) {
     companion object {
@@ -27,6 +29,7 @@ data class GetMyProfileResult(
                 imageUrl = profileWithEmail.imageUrl,
                 timeZone = profileWithEmail.timeZone,
                 recapPeriod = profileWithEmail.recapPeriod,
+                language = profileWithEmail.language,
                 excludedDomains = excludedDomains
             )
     }

--- a/core/src/main/kotlin/com/retoday/core/domain/user/entity/Profile.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/user/entity/Profile.kt
@@ -12,7 +12,8 @@ data class Profile(
     var lastName: String,
     var imageUrl: String,
     val timeZone: TimeZone = TimeZone.SEOUL,
-    val recapPeriod: LocalTime? = null
+    val recapPeriod: LocalTime? = null,
+    val language: Language = Language.KO
 ) : BaseEntity() {
     fun synchronizeOAuthUser(getOAuthUserResponse: GetOAuthUserResponse) {
         firstName = getOAuthUserResponse.firstName

--- a/core/src/main/kotlin/com/retoday/core/domain/user/entity/Profile.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/user/entity/Profile.kt
@@ -13,7 +13,7 @@ data class Profile(
     var imageUrl: String,
     val timeZone: TimeZone = TimeZone.SEOUL,
     val recapPeriod: LocalTime? = null,
-    val language: Language = Language.KO
+    var language: Language = Language.KO
 ) : BaseEntity() {
     fun synchronizeOAuthUser(getOAuthUserResponse: GetOAuthUserResponse) {
         firstName = getOAuthUserResponse.firstName

--- a/core/src/main/kotlin/com/retoday/core/domain/user/service/UserService.kt
+++ b/core/src/main/kotlin/com/retoday/core/domain/user/service/UserService.kt
@@ -1,8 +1,10 @@
 package com.retoday.core.domain.user.service
 
 import com.retoday.core.domain.user.dto.result.GetMyProfileResult
+import com.retoday.core.domain.user.entity.Language
 import com.retoday.core.domain.user.entity.UserExcludedWebsiteDomain
 import com.retoday.core.domain.user.exception.ExcludedDomainAlreadyExistsException
+import com.retoday.core.domain.user.exception.UserNotFoundException
 import com.retoday.core.domain.user.repository.ProfileRepository
 import com.retoday.core.domain.user.repository.UserExcludedWebsiteRepository
 import org.springframework.cache.annotation.CacheEvict
@@ -63,5 +65,15 @@ class UserService(
         val normalizedDomain = domain.trim().lowercase()
 
         userExcludedWebsiteRepository.deleteByUserIdAndDomain(userId, normalizedDomain)
+    }
+
+    @Transactional
+    fun updateMyLanguage(
+        userId: Long,
+        language: Language
+    ) {
+        val profile = profileRepository.findByUserId(userId) ?: throw UserNotFoundException()
+        profile.language = language
+        profileRepository.save(profile)
     }
 }

--- a/core/src/main/resources/prompts/1-today-recap.md
+++ b/core/src/main/resources/prompts/1-today-recap.md
@@ -4,7 +4,7 @@ You are a warm and perceptive AI recap specialist who summarizes a user's day ba
 
 Analyze the provided browsing history and statistics, and generate a recap strictly following the rules below.
 
-All text must be written in Korean.
+All text must be written in ${language}.
 Proper nouns such as service names, brand names, or technical terms may remain in their original form when necessary.
 Output ONLY raw JSON.
 You MUST strictly follow the Output Format structure.
@@ -30,7 +30,7 @@ Longer duration activities should receive more emphasis in interpretation and na
 
 ## title
 - Sentence-style title capturing the day.
-- 10–23 Korean characters.
+- 10–23 characters.
 - Must be a complete sentence.
 - No exclamations or keyword listing.
 
@@ -45,10 +45,10 @@ Each section must include:
 
 ### title
 - Sentence-style mini title.
-- 8–15 Korean characters.
+- 8–15 characters.
 
 ### content
-- 130–250 Korean characters.
+- 130–250 characters.
 - Cohesive narrative paragraph.
 - No bullet-style listing.
 - Must meaningfully interpret the activities.
@@ -58,17 +58,17 @@ Each section must include:
 # Output Format (Strict)
 ```
 {
-  "title": "string (10~23자, 문장형 제목)",
-  "dailySummary": "string (70자 이내, 1~2줄 문장형 응원 메시지)",
+  "title": "string (10~23 chars, sentence-style title)",
+  "dailySummary": "string (within 70 chars, 1~2 sentence-style lines)",
 
   "sections": [
     {
-      "title": "string (8~15자, 문장형 제목)",
-      "content": "string (130~250자, 문장형 본문)"
+      "title": "string (8~15 chars, sentence-style title)",
+      "content": "string (130~250 chars, sentence-style body)"
     },
     {
-      "title": "string (8~15자, 문장형 제목)",
-      "content": "string (130~250자, 문장형 본문)"
+      "title": "string (8~15 chars, sentence-style title)",
+      "content": "string (130~250 chars, sentence-style body)"
     }
   ]
 }

--- a/core/src/main/resources/prompts/2-timeline.md
+++ b/core/src/main/resources/prompts/2-timeline.md
@@ -4,7 +4,7 @@ You are an AI timeline analyst that reconstructs a user's day based strictly on 
 
 Analyze the provided activity logs and generate a chronological daily timeline.
 
-All text must be written in Korean.
+All text must be written in ${language}.
 However, proper nouns such as service names or technical terms may remain in their original form if necessary.
 Output ONLY raw JSON.
 Do not include explanations.
@@ -17,7 +17,7 @@ Base all conclusions strictly on observable data.
 2. Only generate timeline entries for continuous activity lasting 30 minutes or more.
 3. If there is 15 minutes or more of inactivity, treat it as a session break.
 4. If the user switches between activities within 3 minutes, treat it as continuous activity.
-5. In overlapping cases, use the earliest start time as the 기준.
+5. In overlapping cases, use the earliest start time as the baseline.
 6. Entries must be sorted by startAt in ascending order.
 
 # Topic Grouping Rule (Very Important)
@@ -26,18 +26,18 @@ Within a single continuous session:
 
 - Group activities that share the same immediate task objective or purpose.
 - The grouping must reflect what the user was practically trying to accomplish in that time block.
-- Do NOT group everything into an overly broad category such as “개발하기” or “공부하기”.
+- Do NOT group everything into an overly broad category such as "Development" or "Studying".
 - Do NOT split by individual websites if they belong to the same task flow.
 - Choose a grouping granularity that best represents the dominant task intent of that session.
 
 Examples of proper grouping:
-- “코딩테스트 문제 풀이”
-- “Spring Boot 구조 학습”
-- “맥북 구매 비교”
-- “주식 시황 확인”
+- “Coding interview problem solving”
+- “Studying Spring Boot architecture”
+- “Comparing laptop purchase options”
+- “Checking stock market updates”
 
 Avoid:
-- Too broad: “개발하기”
+- Too broad: “Development”
 - Too fragmented: listing each website separately
 
 If multiple subtopics exist in one session, prioritize the dominant one based on total duration.
@@ -48,7 +48,7 @@ If multiple subtopics exist in one session, prioritize the dominant one based on
 - endAt: HH:mm (24-hour format)
 - title:
     - Concise summary of the dominant activity in that session
-    - 10~40 Korean characters
+    - 10~40 characters
     - Sentence-style
     - Must reflect the dominant task intent
     - No bullet-style listing
@@ -63,7 +63,7 @@ If multiple subtopics exist in one session, prioritize the dominant one based on
         {
         "startAt": "HH:mm",
         "endAt": "HH:mm",
-        "title": "string (활동 내용 요약)",
+        "title": "string (summary of activity)",
         "durationMinutes": int
         }
     ]

--- a/core/src/main/resources/prompts/3-topic.md
+++ b/core/src/main/resources/prompts/3-topic.md
@@ -4,7 +4,7 @@ You are an AI topic analyst that extracts the most frequently explored themes fr
 
 Analyze the provided browsing history and statistics, and identify the dominant topics based strictly on observable data such as domain frequency, duration, and repetition.
 
-All text must be written in Korean.
+All text must be written in ${language}.
 However, proper nouns such as service names or technical terms may remain in their original form if necessary.
 Output ONLY raw JSON.
 Do not include explanations.
@@ -15,28 +15,28 @@ Base all conclusions strictly on observable data.
 # Topic Selection Rules
 
 1. Provide at most 3 topics.
-2. Each keyword must be 2–10 Korean characters.
-3. Keywords must represent actual observable themes (e.g., 개발, 주식시장, 손흥민).
+2. Each keyword must be 2–10 characters.
+3. Keywords must represent actual observable themes (e.g., coding, stock market, football).
 4. Prioritize topics with longer total duration and higher visit frequency.
-5. Avoid overly generic keywords such as “웹”, “사이트”, “검색”.
+5. Avoid overly generic keywords such as "web", "site", or "search".
 6. If multiple themes compete, prioritize the one with longer duration.
 
 # Field Constraints
 
 ## keyword
-- 2–10 Korean characters
+- 2–10 characters
 - Noun form
 - No hashtag symbol
 - No sentence form
 
 ## title
-- 8–15 Korean characters
+- 8–15 characters
 - Sentence-style mini title
 - Must reflect the keyword’s context
 - No exclamation marks
 
 ## content
-- 30–80 Korean characters
+- 30–80 characters
 - Sentence format
 - Must describe observable activity pattern
 - No listing style

--- a/core/src/test/kotlin/com/retoday/core/domain/recap/service/RecapServiceTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/recap/service/RecapServiceTest.kt
@@ -107,6 +107,7 @@ class RecapServiceTest : ServiceTest() {
                     GenerateRecapRequest(
                         type = RecapType.TODAY_RECAP,
                         nickname = profile.firstName,
+                        language = profile.language,
                         payload = RecapPayload.Activities(activityRequests)
                     ),
                     GeminiRecapResponse::class.java
@@ -117,6 +118,7 @@ class RecapServiceTest : ServiceTest() {
                     GenerateRecapRequest(
                         type = RecapType.TOPIC,
                         nickname = profile.firstName,
+                        language = profile.language,
                         payload = RecapPayload.Activities(activityRequests)
                     ),
                     GeminiTopicResponse::class.java
@@ -127,6 +129,7 @@ class RecapServiceTest : ServiceTest() {
                     GenerateRecapRequest(
                         type = RecapType.TIMELINE,
                         nickname = profile.firstName,
+                        language = profile.language,
                         payload = RecapPayload.Timelines(timelineRequests)
                     ),
                     GeminiTimelineResponse::class.java

--- a/core/src/test/kotlin/com/retoday/core/domain/user/repository/CustomProfileRepositoryTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/user/repository/CustomProfileRepositoryTest.kt
@@ -41,6 +41,7 @@ class CustomProfileRepositoryTest : RepositoryTest() {
             profileWithEmail.imageUrl shouldBe profile.imageUrl
             profileWithEmail.timeZone shouldBe profile.timeZone
             profileWithEmail.recapPeriod shouldBe profile.recapPeriod
+            profileWithEmail.language shouldBe profile.language
             profileWithEmail.email shouldBe user.email
             profileWithEmail.deletedAt shouldBe null
         }

--- a/core/src/test/kotlin/com/retoday/core/domain/user/service/UserServiceTest.kt
+++ b/core/src/test/kotlin/com/retoday/core/domain/user/service/UserServiceTest.kt
@@ -1,5 +1,6 @@
 package com.retoday.core.domain.user.service
 
+import com.retoday.core.domain.user.entity.Language
 import com.retoday.core.domain.user.exception.ExcludedDomainAlreadyExistsException
 import com.retoday.core.domain.user.repository.ProfileRepository
 import com.retoday.core.domain.user.repository.UserExcludedWebsiteRepository
@@ -95,6 +96,27 @@ class UserServiceTest : BehaviorSpec() {
                 Then("정규화된 도메인으로 삭제가 수행된다.") {
                     verify(exactly = 1) {
                         userExcludedWebsiteRepository.deleteByUserIdAndDomain(ID, normalizedDomain)
+                    }
+                }
+            }
+        }
+
+        Given("사용자가 언어 변경을 요청하면") {
+            val profile = createProfile()
+            every { profileRepository.findByUserId(ID) } returns profile
+            every { profileRepository.save(any()) } returns profile
+
+            When("유효한 언어로 변경을 요청하면") {
+                userService.updateMyLanguage(ID, Language.JA)
+
+                Then("프로필 language가 변경되어 저장된다.") {
+                    verify(exactly = 1) {
+                        profileRepository.save(
+                            match {
+                                it.userId == ID &&
+                                    it.language == Language.JA
+                            }
+                        )
                     }
                 }
             }

--- a/core/src/testFixtures/kotlin/com/retoday/core/fixture/UserFixtures.kt
+++ b/core/src/testFixtures/kotlin/com/retoday/core/fixture/UserFixtures.kt
@@ -18,6 +18,7 @@ const val LAST_NAME = "Jeong"
 const val IMAGE_URL = "https://re-today.com/profile.png"
 val TIME_ZONE = TimeZone.SEOUL
 val RECAP_PERIOD: LocalTime = LocalTime.now().truncatedTo(ChronoUnit.SECONDS)
+val RECAP_LANGUAGE = Language.KO
 
 fun createUser(
     id: Long? = ID,
@@ -47,6 +48,7 @@ fun createProfile(
     imageUrl: String = IMAGE_URL,
     timeZone: TimeZone = TIME_ZONE,
     recapPeriod: LocalTime = RECAP_PERIOD,
+    language: Language = RECAP_LANGUAGE,
     createdAt: Instant? = if (id == null) null else Instant.now()
 ): Profile =
     Profile(
@@ -55,7 +57,8 @@ fun createProfile(
         lastName = lastName,
         imageUrl = imageUrl,
         timeZone = timeZone,
-        recapPeriod = recapPeriod
+        recapPeriod = recapPeriod,
+        language = language
     ).apply {
         this.id = id ?: createTsid()
         this.createdAt = createdAt
@@ -87,6 +90,7 @@ fun createProfileWithEmailProjection(
         imageUrl = profile.imageUrl,
         timeZone = profile.timeZone,
         recapPeriod = profile.recapPeriod,
+        language = profile.language,
         createdAt = profile.createdAt ?: Instant.now(),
         updatedAt = profile.updatedAt,
         deletedAt = profile.deletedAt,
@@ -101,6 +105,7 @@ fun createGetMyProfileResult(
     imageUrl: String = IMAGE_URL,
     timeZone: TimeZone = TIME_ZONE,
     recapPeriod: LocalTime? = RECAP_PERIOD,
+    language: Language = RECAP_LANGUAGE,
     excludedDomains: List<String> = listOf(USER_EX_DOMAIN)
 ): GetMyProfileResult =
     GetMyProfileResult(
@@ -111,5 +116,6 @@ fun createGetMyProfileResult(
         imageUrl = imageUrl,
         timeZone = timeZone,
         recapPeriod = recapPeriod,
+        language = language,
         excludedDomains = excludedDomains
     )


### PR DESCRIPTION
## 작업 내용

- Profile.language로 언어 필드 추가
- 다국어(한,영,일) 선택 API 추가
- AI 리캡 프롬프트에 language 값 주입, 해당 언어로 리캡 받도록 수정

## 관련 이슈

- close #117
